### PR TITLE
Add rudimentary presence support

### DIFF
--- a/explainer-client/src/main/scala/presence/PresenceClient.scala
+++ b/explainer-client/src/main/scala/presence/PresenceClient.scala
@@ -1,0 +1,39 @@
+package presence
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.ScalaJSDefined
+
+@ScalaJSDefined
+class Person(val firstName: String, val lastName: String, val email: String) extends js.Object
+
+@js.native
+object PresenceGlobalScope extends js.GlobalScope {
+
+  def presenceClient(endpoint: String, person: Person): PresenceClient = js.native
+}
+
+@js.native
+trait PresenceClient extends js.Object {
+  def startConnection(): Unit = js.native
+
+  def on(presenceEvent: String, callback: js.Function1[js.Object, Unit]): Unit = js.native
+
+  def subscribe(id: String): Unit = js.native
+
+  def enter(articleId: String, articleLocation: String): Unit = js.native
+}
+
+
+
+object StateChange {
+
+  case class Person(firstName: String, lastName: String, email: String) {
+    val initials = Seq(firstName, lastName).flatMap(_.headOption).mkString
+  }
+
+  case class ClientId(connId: String, person: Person)
+
+  case class State(clientId: ClientId, location: String)
+}
+
+case class StateChange(currentState: Seq[StateChange.State])

--- a/explainer-server/app/views/templates/main.scala.html
+++ b/explainer-server/app/views/templates/main.scala.html
@@ -6,6 +6,7 @@
   <head>
     <meta charset="utf-8">
     <title>Play with scala.js showcase - @title</title>
+    <script src="https://presence.code.dev-gutools.co.uk/client/1/lib.js"></script>
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/favicon.png")" />
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("lib/bootstrap/css/bootstrap.min.css")" />
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/main.css")" />

--- a/explainer-server/public/stylesheets/explainer.css
+++ b/explainer-server/public/stylesheets/explainer.css
@@ -56,6 +56,16 @@ body, p {
     border-top: 1px dotted #adadad;
 }
 
+.presence-field-container {
+    position: relative;
+}
+
+.field-presence-indicator {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+}
+
 
 /*
         Hack to remove background from Mobile Safari.


### PR DESCRIPTION
This manages to register at:

https://presence.code.dev-gutools.co.uk/api/currentState

...and then get state updates, put those into rough-and-ready status indicators

Note that to get this to work you currently need to have recently (last 30 minutes or so?) visited a PANDA-enabled app like https://composer.code.dev-gutools.co.uk - because the explainer tool currently doesn't do any panda stuff itself.

cc @lindseydew
