### PR TITLE
Tweak to get extra diagnostic information from `sbt-riffraff-artifact`

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -15,6 +15,6 @@ addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.0")
 
-addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.4")
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.5")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")


### PR DESCRIPTION
There's a small bit of extra info added with https://github.com/guardian/sbt-riffraff-artifact/pull/21 and I just want to test it out.
