### PR TITLE
Fixing Broken Explainer Page

### DIFF
--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -5,6 +5,6 @@
 }
 @templates.main("Explainer Editor", header){
 
-    <script>example.ExplainEditorJS().main("@id")</script>
+    <script>ExplainEditorJS().main("@id")</script>
 
 }


### PR DESCRIPTION
Previous commit broke the Explainer page after moving an object
