### PR TITLE
Fix CSS bug in the display of the dashboard

### DIFF
--- a/explainer-server/public/stylesheets/explainer.css
+++ b/explainer-server/public/stylesheets/explainer.css
@@ -138,7 +138,7 @@ h2, h3, h4, h5, h6, .preview__title, .preview__score {
     border-bottom: 1px solid #ededed;
 }
 
-.dashboard__body__listing__item :hover {
+.dashboard__body__listing__item:hover {
     background-color: #ededed;
 }
 


### PR DESCRIPTION
The extra space was causing the hover directive to be applied
to children of the element at opposition of the element itself.
