### PR TITLE
Update in AuthActions

### DIFF
--- a/explainer-server/app/actions.scala
+++ b/explainer-server/app/actions.scala
@@ -28,7 +28,7 @@ trait AuthActions {
     case Some(Authenticated(u)) => Some(u)
     case _ => None
   }, onUnauthorized = req => {
-    val requestUrl = s"https://${req.host}/${req.path}"
+    val requestUrl = s"https://explainer.${Config.pandaDomain}/${req.path}"
     val loginRedirect = Redirect(s"https://login.${Config.pandaDomain}/login", Map("returnUrl" -> Seq(requestUrl)))
       userAuthStatusOptFor(req).map {
         case NotAuthorized(u) => Forbidden(s"Sorry, ${u.user.emailDomain} is not authorized to use this tool")


### PR DESCRIPTION
Ensures that the url passed to login.gutools has the correct form.
Otherwise the user has to manually come back to the app trying to authenticate.

Test:
1. Load https://explainer.local.dev-gutools.co.uk normally authenticated.
2. Destroy your Panda cookies (gutoolsAuth and gutoolsAuth-assym).
3. Reload the page.
4. You should then loop back to where you started.
