### PR TITLE
Move the implementation of server side ExplainerApi to a dedicated class

### DIFF
--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -30,7 +30,7 @@ object AutowireServer extends autowire.Server[Js.Value, Reader, Writer]{
   def write[Result: Writer](r: Result) = upickle.default.writeJs(r)
 }
 
-class ExplainerApiC(
+class ExplainerApiImpl(
   config: Config,
   previewAtomPublisher: PreviewAtomPublisher,
   liveAtomPublisher: LiveAtomPublisher,
@@ -87,7 +87,7 @@ class ApiController @Inject() (val config: Config,
       path.split("/"),
       upickle.json.read(request.body.toString()).asInstanceOf[Js.Obj].value.toMap
     )
-    val api = new ExplainerApiC(config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
+    val api = new ExplainerApiImpl(config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
     AutowireServer.route[ExplainerApi](api)(autowireRequest).map(responseJS => {
       Ok(upickle.json.write(responseJS))
     })

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -30,25 +30,15 @@ object AutowireServer extends autowire.Server[Js.Value, Reader, Writer]{
   def write[Result: Writer](r: Result) = upickle.default.writeJs(r)
 }
 
-class ApiController @Inject() (config: Config, previewAtomPublisher: PreviewAtomPublisher,
-  val publicSettingsService: PublicSettingsService,
-  val liveAtomPublisher: LiveAtomPublisher) extends Controller with ExplainerApi with AuthActions  {
+class ExplainerApiC(
+  config: Config,
+  previewAtomPublisher: PreviewAtomPublisher,
+  liveAtomPublisher: LiveAtomPublisher,
+  val publicSettingsService: PublicSettingsService) extends ExplainerApi with AuthActions {
 
   val explainerDB = new ExplainerDB(config)
   val explainerStore = new ExplainerStore(config)
-
   val pandaAuthenticated = new PandaAuthenticated(config)
-
-  def autowireApi(path: String) = pandaAuthenticated.async(parse.json) { implicit request =>
-    val autowireRequest: Request[Js.Value] = autowire.Core.Request(
-      path.split("/"),
-      upickle.json.read(request.body.toString()).asInstanceOf[Js.Obj].value.toMap
-    )
-
-    AutowireServer.route[ExplainerApi](this)(autowireRequest).map(responseJS => {
-      Ok(upickle.json.write(responseJS))
-    })
-  }
 
   def publishExplainerToKinesis(explainer: Atom, actionMessage: String, atomPublisher: AtomPublisher) = {
     if (config.publishToKinesis) {
@@ -61,7 +51,6 @@ class ApiController @Inject() (config: Config, previewAtomPublisher: PreviewAtom
     else {
       Logger.info(s"Not $actionMessage - kinesis publishing disabled in config")
     }
-
   }
 
   override def update(id: String, fieldName: String, value: String): Future[CsAtom] = {
@@ -83,6 +72,26 @@ class ApiController @Inject() (config: Config, previewAtomPublisher: PreviewAtom
     val explainerToPublish = explainerDB.load(id)
     explainerToPublish.map(publishExplainerToKinesis(_, "Publishing explainer to LIVE kinesis", liveAtomPublisher))
     explainerToPublish.map(CsAtom.atomToCsAtom)
+  }
+
+}
+
+class ApiController @Inject() (val config: Config,
+  val previewAtomPublisher: PreviewAtomPublisher,
+  val publicSettingsService: PublicSettingsService,
+  val liveAtomPublisher: LiveAtomPublisher) extends Controller with AuthActions {
+
+  val pandaAuthenticated = new PandaAuthenticated(config)
+
+  def autowireApi(path: String) = pandaAuthenticated.async(parse.json) { implicit request =>
+    val autowireRequest: Request[Js.Value] = autowire.Core.Request(
+      path.split("/"),
+      upickle.json.read(request.body.toString()).asInstanceOf[Js.Obj].value.toMap
+    )
+    val api = new ExplainerApiC(config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
+    AutowireServer.route[ExplainerApi](api)(autowireRequest).map(responseJS => {
+      Ok(upickle.json.write(responseJS))
+    })
   }
 
 }

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -34,11 +34,10 @@ class ExplainerApiC(
   config: Config,
   previewAtomPublisher: PreviewAtomPublisher,
   liveAtomPublisher: LiveAtomPublisher,
-  val publicSettingsService: PublicSettingsService) extends ExplainerApi with AuthActions {
+  val publicSettingsService: PublicSettingsService) extends ExplainerApi {
 
   val explainerDB = new ExplainerDB(config)
   val explainerStore = new ExplainerStore(config)
-  val pandaAuthenticated = new PandaAuthenticated(config)
 
   def publishExplainerToKinesis(explainer: Atom, actionMessage: String, atomPublisher: AtomPublisher) = {
     if (config.publishToKinesis) {


### PR DESCRIPTION
In order to implement the user update of atoms, I need to move the implementation of trait `ApiController` from the `ApiController` to a dedicated class.
