### PR TITLE
Enabling user in contentChangeDetails

### DIFF
--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -31,6 +31,7 @@ object AutowireServer extends autowire.Server[Js.Value, Reader, Writer]{
 }
 
 class ExplainerApiImpl(
+  user: com.gu.pandomainauth.model.User,
   config: Config,
   previewAtomPublisher: PreviewAtomPublisher,
   liveAtomPublisher: LiveAtomPublisher,
@@ -53,7 +54,7 @@ class ExplainerApiImpl(
   }
 
   override def update(id: String, fieldName: String, value: String): Future[CsAtom] = {
-    val updatedExplainer = explainerStore.update(id, Symbol(fieldName), value)
+    val updatedExplainer = explainerStore.update(user, id, Symbol(fieldName), value)
     updatedExplainer.map(publishExplainerToKinesis(_, "Publishing explainer update to PREVIEW kinesis", previewAtomPublisher))
     updatedExplainer.map(CsAtom.atomToCsAtom)
   }
@@ -61,7 +62,7 @@ class ExplainerApiImpl(
   override def load(id: String): Future[CsAtom] = explainerDB.load(id).map(CsAtom.atomToCsAtom)
 
   override def create(): Future[CsAtom] = {
-    val newExplainer = explainerStore.create()
+    val newExplainer = explainerStore.create(user)
     newExplainer.map(publishExplainerToKinesis(_, "Publishing new explainer to PREVIEW kinesis", previewAtomPublisher))
     newExplainer.map(e => CsAtom.atomToCsAtom(e))
 
@@ -87,7 +88,7 @@ class ApiController @Inject() (val config: Config,
       path.split("/"),
       upickle.json.read(request.body.toString()).asInstanceOf[Js.Obj].value.toMap
     )
-    val api = new ExplainerApiImpl(config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
+    val api = new ExplainerApiImpl(request.user.user, config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
     AutowireServer.route[ExplainerApi](api)(autowireRequest).map(responseJS => {
       Ok(upickle.json.write(responseJS))
     })

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -54,7 +54,7 @@ class ExplainerApiImpl(
   }
 
   override def update(id: String, fieldName: String, value: String): Future[CsAtom] = {
-    val updatedExplainer = explainerStore.update(user, id, Symbol(fieldName), value)
+    val updatedExplainer = explainerStore.update(id, Symbol(fieldName), value, user)
     updatedExplainer.map(publishExplainerToKinesis(_, "Publishing explainer update to PREVIEW kinesis", previewAtomPublisher))
     updatedExplainer.map(CsAtom.atomToCsAtom)
   }
@@ -69,6 +69,7 @@ class ExplainerApiImpl(
   }
 
   override def publish(id: String): Future[CsAtom] = {
+    val _ = explainerStore.publish(id, user)
     val explainerToPublish = explainerDB.load(id)
     explainerToPublish.map(publishExplainerToKinesis(_, "Publishing explainer to LIVE kinesis", liveAtomPublisher))
     explainerToPublish.map(CsAtom.atomToCsAtom)

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -24,6 +24,7 @@ import upickle.default._
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import com.gu.pandomainauth.model.{User => PandaUser}
 
 object AutowireServer extends autowire.Server[Js.Value, Reader, Writer]{
   def read[Result: Reader](p: Js.Value) = upickle.default.readJs[Result](p)
@@ -31,11 +32,11 @@ object AutowireServer extends autowire.Server[Js.Value, Reader, Writer]{
 }
 
 class ExplainerApiImpl(
-  user: com.gu.pandomainauth.model.User,
   config: Config,
   previewAtomPublisher: PreviewAtomPublisher,
   liveAtomPublisher: LiveAtomPublisher,
-  val publicSettingsService: PublicSettingsService) extends ExplainerApi {
+  val publicSettingsService: PublicSettingsService,
+  user: PandaUser) extends ExplainerApi {
 
   val explainerDB = new ExplainerDB(config)
   val explainerStore = new ExplainerStore(config)
@@ -89,7 +90,7 @@ class ApiController @Inject() (val config: Config,
       path.split("/"),
       upickle.json.read(request.body.toString()).asInstanceOf[Js.Obj].value.toMap
     )
-    val api = new ExplainerApiImpl(request.user.user, config, previewAtomPublisher, liveAtomPublisher, publicSettingsService)
+    val api = new ExplainerApiImpl(config, previewAtomPublisher, liveAtomPublisher, publicSettingsService, request.user.user)
     AutowireServer.route[ExplainerApi](api)(autowireRequest).map(responseJS => {
       Ok(upickle.json.write(responseJS))
     })

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -84,9 +84,8 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
 
   def publish(id: String, user: PandaUser): Future[Atom] = {
     explainerDB.load(id).map{ explainer =>
-      val newExplainerAtom = ExplainerAtom(explainer.tdata.title, explainer.tdata.body, explainer.tdata.displayType)
       val contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), false, false, true)
-      val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, contentChangeDetails, user)
+      val updatedExplainer = buildAtomWithDefaults(explainer.id, explainer.tdata, contentChangeDetails, user)
       explainerDB.store(updatedExplainer)
       updatedExplainer
     }

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -30,6 +30,10 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     )
   }
 
+  def pandaUserToAtomUser(user: PandaUser): Option[User] = {
+    Some(User(user.email,Some(user.firstName),Some(user.lastName)))
+  }
+
   def update(id: String, fieldSymbol: Symbol, value: String, user: PandaUser): Future[Atom] = {
     val allowed_fields = Set(
       "title",
@@ -50,7 +54,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
       }
       val contentChangeDetails = ContentChangeDetails(
         created      = explainer.contentChangeDetails.created,
-        lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
+        lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=pandaUserToAtomUser(user))),
         published    = explainer.contentChangeDetails.published,
         revision = explainer.contentChangeDetails.revision+1
       )
@@ -64,8 +68,8 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     val uuid = java.util.UUID.randomUUID.toString
     val explainerAtom = ExplainerAtom("-", "-", DisplayType.Expandable)
     val contentChangeDetails = ContentChangeDetails(
-      created      = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
-      lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
+      created      = Some(ChangeRecord(DateTime.now.getMillis, user=pandaUserToAtomUser(user))),
+      lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=pandaUserToAtomUser(user))),
       published    = None,
       revision = 1
     )
@@ -80,7 +84,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
       val contentChangeDetails = ContentChangeDetails(
         created      = explainer.contentChangeDetails.created,
         lastModified = explainer.contentChangeDetails.lastModified,
-        published    = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
+        published    = Some(ChangeRecord(DateTime.now.getMillis, user=pandaUserToAtomUser(user))),
         revision     = explainer.contentChangeDetails.revision+1
       )
       val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, contentChangeDetails, user)

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -85,7 +85,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
   def publish(id: String, user: PandaUser): Future[Atom] = {
     explainerDB.load(id).map{ explainer =>
       val newExplainerAtom = ExplainerAtom(explainer.tdata.title, explainer.tdata.body, explainer.tdata.displayType)
-      val contentChangeDetails = contentChangeDetailsBuilder(user, None, false, false, true)
+      val contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), false, false, true)
       val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, contentChangeDetails, user)
       explainerDB.store(updatedExplainer)
       updatedExplainer

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -44,7 +44,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
       created      = buildChangeRecord(existingContentChangeDetails.flatMap(_.created)     , updateCreated),
       lastModified = buildChangeRecord(existingContentChangeDetails.flatMap(_.lastModified), updateLastModified),
       published    = buildChangeRecord(existingContentChangeDetails.flatMap(_.published)   , updatePublished),
-      revision     = existingContentChangeDetails.map(_.revision).getOrElse(1)
+      revision     = existingContentChangeDetails.map(_.revision).getOrElse(0L) + 1
     )
   }
 

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -18,17 +18,19 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
 
   val explainerDB = new ExplainerDB(config)
 
-  def buildAtomWithDefaults(id: String, explainerAtom: ExplainerAtom, revision: Long): Atom = {
+  def buildAtomWithDefaults(user: com.gu.pandomainauth.model.User, id: String, explainerAtom: ExplainerAtom, revision: Long): Atom = {
     Atom(
       id = id,
       atomType = AtomType.Explainer,
       defaultHtml = "",
       data = AtomData.Explainer(explainerAtom),
-      contentChangeDetails = ContentChangeDetails(lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=None)), revision = revision)
+      contentChangeDetails = ContentChangeDetails(
+        lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
+        revision = revision)
     )
   }
 
-  def update(id: String, fieldSymbol: Symbol, value: String): Future[Atom] = {
+  def update(user: com.gu.pandomainauth.model.User, id: String, fieldSymbol: Symbol, value: String): Future[Atom] = {
     val allowed_fields = Set(
       "title",
       "body",
@@ -46,16 +48,16 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
           }
         }
       }
-      val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, explainer.contentChangeDetails.revision+1)
+      val updatedExplainer = buildAtomWithDefaults(user, explainer.id, newExplainerAtom, explainer.contentChangeDetails.revision+1)
       explainerDB.store(updatedExplainer)
       updatedExplainer
     }
   }
 
-  def create(): Future[Atom] = {
+  def create(user: com.gu.pandomainauth.model.User): Future[Atom] = {
     val uuid = java.util.UUID.randomUUID.toString
     val explainerAtom = ExplainerAtom("-", "-", DisplayType.Expandable)
-    val explainer = buildAtomWithDefaults(uuid, explainerAtom, 1)
+    val explainer = buildAtomWithDefaults(user, uuid, explainerAtom, 1)
     explainerDB.store(explainer)
     Future(explainer)
   }

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -49,8 +49,11 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
         }
       }
       val contentChangeDetails = ContentChangeDetails(
+        created      = explainer.contentChangeDetails.created,
         lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
-        revision = explainer.contentChangeDetails.revision+1)
+        published    = explainer.contentChangeDetails.published,
+        revision = explainer.contentChangeDetails.revision+1
+      )
       val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, contentChangeDetails, user)
       explainerDB.store(updatedExplainer)
       updatedExplainer
@@ -61,8 +64,11 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     val uuid = java.util.UUID.randomUUID.toString
     val explainerAtom = ExplainerAtom("-", "-", DisplayType.Expandable)
     val contentChangeDetails = ContentChangeDetails(
+      created      = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
       lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
-      revision = 1)
+      published    = None,
+      revision = 1
+    )
     val explainer = buildAtomWithDefaults(uuid, explainerAtom, contentChangeDetails, user)
     explainerDB.store(explainer)
     Future(explainer)
@@ -72,8 +78,11 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     explainerDB.load(id).map{ explainer =>
       val newExplainerAtom = ExplainerAtom(explainer.tdata.title, explainer.tdata.body, explainer.tdata.displayType)
       val contentChangeDetails = ContentChangeDetails(
-        lastModified = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
-        revision = explainer.contentChangeDetails.revision+1)
+        created      = explainer.contentChangeDetails.created,
+        lastModified = explainer.contentChangeDetails.lastModified,
+        published    = Some(ChangeRecord(DateTime.now.getMillis, user=Some(User(user.email,Some(user.firstName),Some(user.lastName))))),
+        revision     = explainer.contentChangeDetails.revision+1
+      )
       val updatedExplainer = buildAtomWithDefaults(explainer.id, newExplainerAtom, contentChangeDetails, user)
       explainerDB.store(updatedExplainer)
       updatedExplainer


### PR DESCRIPTION
This change brings the setting of the user in the contentChangeDetails of atoms.
It builds on the work made in the previous change :)
