### PR TITLE
Stop showing a hyphen in empty fields

### DIFF
--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -75,7 +75,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
 
   def create(user: PandaUser): Future[Atom] = {
     val uuid = java.util.UUID.randomUUID.toString
-    val explainerAtom = ExplainerAtom("-", "-", DisplayType.Expandable)
+    val explainerAtom = ExplainerAtom("", "", DisplayType.Expandable)
     val contentChangeDetails = contentChangeDetailsBuilder(user, None, true, true, false)
     val explainer = buildAtomWithDefaults(uuid, explainerAtom, contentChangeDetails, user)
     explainerDB.store(explainer)


### PR DESCRIPTION
When explain maker was born the title and body were top fields of DynamoDB table records.
Due to a limitation in the value of DynamoDB table top fields, the title and body needed
to be non empty, and were set to be a single dash. We no longer have this limitation.
