### PR TITLE
Introduce Tinymce as Explainer body editor

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -3,7 +3,7 @@ import autowire._
 import common.ExtAjax._
 import org.scalajs.dom
 import org.scalajs.dom.ext.Ajax
-import org.scalajs.dom.html.{Element, Input, TextArea, Option}
+import org.scalajs.dom.html.{Element, Input, Option, TextArea}
 import org.scalajs.dom.{Event, FocusEvent}
 import presence.StateChange.State
 import presence.{Person, PresenceGlobalScope, StateChange}
@@ -121,15 +121,13 @@ object ExplainEditorJS {
     }
 
     val body: TypedTag[TextArea] = textarea(
+      id:="explainer-input-text-area",
       cls:="explainer-editor__body-wrapper__input explainer-input-field",
       maxlength:=1800,
       placeholder:="body"
     )
 
     val bodyTag = body(explainer.data.body).render
-    bodyTag.onchange = (x: Event) => {
-      Model.updateFieldContent(explainerId, ExplainerUpdate("body", bodyTag.value)).map(republishStatusBar)
-    }
     bodyTag.oninput = (x: Event) => {
       g.updateWordCountDisplay()
       g.updateWordCountWarningDisplay()
@@ -200,6 +198,7 @@ object ExplainEditorJS {
       )
       g.updateWordCountDisplay()
       g.updateWordCountWarningDisplay()
+      g.initiateEditor()
     }
   }
 
@@ -215,4 +214,8 @@ object ExplainEditorJS {
     Model.updateFieldContent(explainerId, ExplainerUpdate("displayType", displayType))
   }
 
+  @JSExport
+  def updateBodyContents(explainerId: String, bodyString: String) = {
+    Model.updateFieldContent(explainerId, ExplainerUpdate("body", bodyString)).map(republishStatusBar)
+  }
 }

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -2,6 +2,7 @@
 
 @header = {
     <link rel="stylesheet" media="screen" href="@routes.Assets.at("stylesheets/explainer.css")">
+    <script src="//cdn.tinymce.com/4/tinymce.min.js"></script>
 }
 @toolbar = {
     <header class="top-toolbar">
@@ -82,4 +83,20 @@
     </script>
 
     <script>ExplainEditorJS().main("@id")</script>
+
+    <script>
+        function initiateEditor(){
+            tinymce.init({
+                selector:'#explainer-input-text-area',
+                setup:function(ed) {
+                    ed.on('change', function(e) {
+                        var bodyString = ed.getContent();
+                        console.log('body ', bodyString);
+                        ExplainEditorJS().updateBodyContents("@id", bodyString)
+                    });
+                }
+            });
+        }
+    </script>
+
 }


### PR DESCRIPTION
In this commit:
- Use Tinymce to edit the body of the explainer.
  Note that it was not possible to let ScalaJS handle the event handler because
  of the DOM restructuration performed by Tinymce, instead we use Tinymce's own
  event handler and we simply moved the body update function to a separate Scala
  function (which is then exported to JavaScript).

Note:
- The import of Tinymce use the CDN, this is on purpose and will be corrected
  in the next commit.
- The body is console logged, this is also on purpose (will be removed in the
  next commit).
