### PR TITLE
Setting the correct editor menus items

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -101,7 +101,6 @@ object ExplainEditorJS {
     status
   }
 
-
   def republishStatusBar(explainer: CsAtom) = {
     g.updateStatusBar(statusBarText(explainer))
   }

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -92,7 +92,7 @@
                 menu: {
                     table: {title: 'Table', items: 'inserttable tableprops deletetable | cell row column'}
                 },
-                toolbar: 'undo redo | styleselect | bold italic underline',
+                toolbar: 'undo redo | styleselect | bold italic underline bullist, numlist',
                 setup:function(ed) {
                     ed.on('change', function(e) {
                         var bodyString = ed.getContent();

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -90,9 +90,9 @@
             tinymce.init({
                 selector:'#explainer-input-text-area',
                 menu: {
-                    table: {title: 'Table', items: 'inserttable tableprops deletetable | cell row column'},
-                    tools: {title: 'Tools', items: 'spellchecker code'}
+                    table: {title: 'Table', items: 'inserttable tableprops deletetable | cell row column'}
                 },
+                toolbar: 'undo redo | styleselect | bold italic underline',
                 setup:function(ed) {
                     ed.on('change', function(e) {
                         var bodyString = ed.getContent();

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -89,6 +89,10 @@
         function initiateEditor(){
             tinymce.init({
                 selector:'#explainer-input-text-area',
+                menu: {
+                    table: {title: 'Table', items: 'inserttable tableprops deletetable | cell row column'},
+                    tools: {title: 'Tools', items: 'spellchecker code'}
+                },
                 setup:function(ed) {
                     ed.on('change', function(e) {
                         var bodyString = ed.getContent();

--- a/explainer-server/public/stylesheets/explainer.css
+++ b/explainer-server/public/stylesheets/explainer.css
@@ -184,7 +184,7 @@ h2, h3, h4, h5, h6, .preview__title, .preview__score {
 
     }
         .explainer-editor__body-wrapper__input {
-            height:500px;
+            height:300px;
             padding: 6px;
         }
 


### PR DESCRIPTION
In this commit we remove the un-necessary menu items that come with the
default settings of Tinymce and only keep those needed for basic rich
text editing.
