### PR TITLE
Fixes a bug with the 'Draft State' status message

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -61,9 +61,9 @@ object ExplainEditorJS {
       Ajaxer[ExplainerApi].create().call()
     }
 
-//    def publish(id: String): Future[CsAtom] = {
-//      Ajaxer[ExplainerApi].publish(id).call()
-//    }
+    def publish(id: String): Future[CsAtom] = {
+      Ajaxer[ExplainerApi].publish(id).call()
+    }
 
   }
 
@@ -97,7 +97,7 @@ object ExplainEditorJS {
       lastModifiedDate <- explainer.contentChangeDetails.lastModified
       publishedDate <- explainer.contentChangeDetails.published
     }yield {
-      lastModifiedDate.date != publishedDate.date
+      lastModifiedDate.date > publishedDate.date
     }).getOrElse(true)
 
     val status = if(isDraftState){
@@ -141,7 +141,9 @@ object ExplainEditorJS {
 
     val publishButton = button(id:="explainer-editor__ops-wrapper__publish-button")("Publish").render
     publishButton.onclick = (x: Event) => {
-//      Model.publish(explainerId).map(republishStatusBar)
+       Model.publish(explainerId).map{ explainer =>
+         republishStatusBar(explainer)
+       }
     }
 
     val checkboxClassName: String = "explainer-editor__displayType-checkbox"
@@ -202,6 +204,7 @@ object ExplainEditorJS {
       dom.document.getElementById("content").appendChild(
         ExplainEditor(explainerId, explainer).render
       )
+      republishStatusBar(explainer)
       g.updateWordCountDisplay()
       g.updateWordCountWarningDisplay()
       g.initiateEditor()

--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -92,7 +92,14 @@ object ExplainEditorJS {
   }
 
   def statusBarText(explainer: CsAtom) = {
-    val isDraftState =  true// !explainer.live.isDefined || explainer.draft.title!=explainer.live.get.title || explainer.draft.body!=explainer.live.get.body
+
+    val isDraftState = (for {
+      lastModifiedDate <- explainer.contentChangeDetails.lastModified
+      publishedDate <- explainer.contentChangeDetails.published
+    }yield {
+      lastModifiedDate.date != publishedDate.date
+    }).getOrElse(true)
+
     val status = if(isDraftState){
       "Draft State"
     }else{
@@ -100,7 +107,6 @@ object ExplainEditorJS {
     }
     status
   }
-
 
   def republishStatusBar(explainer: CsAtom) = {
     g.updateStatusBar(statusBarText(explainer))

--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -141,9 +141,7 @@ object ExplainEditorJS {
 
     val publishButton = button(id:="explainer-editor__ops-wrapper__publish-button")("Publish").render
     publishButton.onclick = (x: Event) => {
-       Model.publish(explainerId).map{ explainer =>
-         republishStatusBar(explainer)
-       }
+      Model.publish(explainerId).map(republishStatusBar)
     }
 
     val checkboxClassName: String = "explainer-editor__displayType-checkbox"


### PR DESCRIPTION
When we moved to the new model we left a bug in the code by which the status message was incorrect. This is now fixed.

Note that we also activated the actual publish code, which was partially commented out. 
