### PR TITLE
CsExplainerAtom update definition to match thrift updated schema

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,7 +92,7 @@ lazy val explainerClient = (project in file("explainer-client")).settings(
 lazy val explainerShared = (crossProject.crossType(CrossType.Pure) in file("explainer-shared")).
   settings(scalaVersion := scalaV,
     libraryDependencies ++= Seq(
-      "com.gu" %% "content-atom-model" % "2.3.0"
+      "com.gu" %% "content-atom-model" % "2.4.2"
     ))
     .jsConfigure(_ enablePlugins ScalaJSPlay)
 

--- a/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
+++ b/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
@@ -4,7 +4,7 @@ import com.gu.contentatom.thrift._
 import contentatom.explainer.{DisplayType, ExplainerAtom}
 import shared.util.ExplainerAtomImplicits
 
-case class CsExplainerAtom(title: String, body: String, displayType: String)
+case class CsExplainerAtom(title: String, body: String, displayType: String, tags: Option[List[String]])
 case class CsUser(email: String, firstName: Option[String], lastName: Option[String])
 case class CsChangeRecord(date: Long, user: Option[CsUser])
 case class CsContentChangeDetails(lastModified: Option[CsChangeRecord], created: Option[CsChangeRecord], published: Option[CsChangeRecord], revision: Long)
@@ -25,7 +25,8 @@ object CsAtom extends ExplainerAtomImplicits {
   private implicit def changeRecordToCsChangeRecord(changeRecord: Option[ChangeRecord]): Option[CsChangeRecord]= changeRecord.map(cr => CsChangeRecord(cr.date, cr.user))
   private implicit def contentChangeDetailsToCsContentChangeDetails(contentChangeDetails: ContentChangeDetails): CsContentChangeDetails =
     CsContentChangeDetails(contentChangeDetails.lastModified, contentChangeDetails.created, contentChangeDetails.published, contentChangeDetails.revision)
-  private implicit def explainerAtomToCsExplainerAtom(explainerAtom: ExplainerAtom): CsExplainerAtom = CsExplainerAtom(explainerAtom.title, explainerAtom.body, explainerAtom.displayType.name)
+  private implicit def optionSeqStringToOptionListString(tags: Option[Seq[String]]): Option[List[String]] = tags.map( x => x.toList )
+  private implicit def explainerAtomToCsExplainerAtom(explainerAtom: ExplainerAtom): CsExplainerAtom = CsExplainerAtom(explainerAtom.title, explainerAtom.body, explainerAtom.displayType.name, explainerAtom.tags)
 
   def atomToCsAtom(atom: Atom) = CsAtom(atom.id, atom.tdata, atom.contentChangeDetails)
 
@@ -36,7 +37,7 @@ object CsAtom extends ExplainerAtomImplicits {
       csContentChangeDetails.created, csContentChangeDetails.published, csContentChangeDetails.revision)
 
   def csAtomToAtom(csAtom: CsAtom) = {
-    val explainerAtom = ExplainerAtom(csAtom.data.title, csAtom.data.body, CsExplainerAtom.stringToDisplayType(csAtom.data.displayType))
+    val explainerAtom = ExplainerAtom(csAtom.data.title, csAtom.data.body, CsExplainerAtom.stringToDisplayType(csAtom.data.displayType), csAtom.data.tags)
     Atom(id = csAtom.id, atomType=AtomType.Explainer, defaultHtml = "",
       data = AtomData.Explainer(explainerAtom), contentChangeDetails = csAtom.contentChangeDetails)
   }

--- a/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
+++ b/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
@@ -25,8 +25,7 @@ object CsAtom extends ExplainerAtomImplicits {
   private implicit def changeRecordToCsChangeRecord(changeRecord: Option[ChangeRecord]): Option[CsChangeRecord]= changeRecord.map(cr => CsChangeRecord(cr.date, cr.user))
   private implicit def contentChangeDetailsToCsContentChangeDetails(contentChangeDetails: ContentChangeDetails): CsContentChangeDetails =
     CsContentChangeDetails(contentChangeDetails.lastModified, contentChangeDetails.created, contentChangeDetails.published, contentChangeDetails.revision)
-  private implicit def optionSeqStringToOptionListString(tags: Option[Seq[String]]): Option[List[String]] = tags.map( x => x.toList )
-  private implicit def explainerAtomToCsExplainerAtom(explainerAtom: ExplainerAtom): CsExplainerAtom = CsExplainerAtom(explainerAtom.title, explainerAtom.body, explainerAtom.displayType.name, explainerAtom.tags)
+  private implicit def explainerAtomToCsExplainerAtom(explainerAtom: ExplainerAtom): CsExplainerAtom = CsExplainerAtom(explainerAtom.title, explainerAtom.body, explainerAtom.displayType.name, explainerAtom.tags.map( _.toList ))
 
   def atomToCsAtom(atom: Atom) = CsAtom(atom.id, atom.tdata, atom.contentChangeDetails)
 


### PR DESCRIPTION
Also in this commit we set the required version of content-atom to 2.4.2
to match the updated tags definition.
