### PR TITLE
Correcting field update bug losing the tags

### DIFF
--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -57,12 +57,12 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     assert(allowed_fields.contains(fieldSymbol.name))
     explainerDB.load(id).map{ explainer =>
       val newExplainerAtom = fieldSymbol.name match {
-        case "title" => ExplainerAtom(value, explainer.tdata.body, explainer.tdata.displayType)
-        case "body" => ExplainerAtom(explainer.tdata.title, value, explainer.tdata.displayType)
+        case "title" => ExplainerAtom(value, explainer.tdata.body, explainer.tdata.displayType, explainer.tdata.tags)
+        case "body" => ExplainerAtom(explainer.tdata.title, value, explainer.tdata.displayType, explainer.tdata.tags)
         case "displayType" => {
           value match {
-            case "Expandable" => ExplainerAtom(explainer.tdata.title, explainer.tdata.body, DisplayType.Expandable)
-            case "Flat" => ExplainerAtom(explainer.tdata.title, explainer.tdata.body, DisplayType.Flat)
+            case "Expandable" => ExplainerAtom(explainer.tdata.title, explainer.tdata.body, DisplayType.Expandable, explainer.tdata.tags)
+            case "Flat" => ExplainerAtom(explainer.tdata.title, explainer.tdata.body, DisplayType.Flat, explainer.tdata.tags)
           }
         }
       }


### PR DESCRIPTION
Updating the `ExplainerStore.update` function which was missing the carry over of the tags.

Testing: 
1. Add some tags to an existing explainer.
2. Update the title, the body, or the display type.
3. Reload the editor and observe that the tags are still there.
