### PR TITLE
Update content atom lib to use new namespace for explainer atoms.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -96,7 +96,7 @@ lazy val explainMakerClient = (project in file("explainer-client")).settings(
 lazy val explainMakerShared = (crossProject.crossType(CrossType.Pure) in file("explainer-shared")).
   settings(scalaVersion := scalaV,
     libraryDependencies ++= Seq(
-      "com.gu" %% "content-atom-model" % "2.4.2"
+      "com.gu" %% "content-atom-model" % "2.4.3"
     ))
     .jsConfigure(_ enablePlugins ScalaJSPlay)
 

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -2,18 +2,17 @@ package models
 
 import com.gu.contentatom.thrift._
 import com.gu.scanamo.{Table, _}
-import contentatom.explainer.{DisplayType, ExplainerAtom}
 import db.ExplainerDB
 import shared._
 import javax.inject.Inject
 
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 import config.Config
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import org.joda.time.DateTime
 import shared.util.ExplainerAtomImplicits
-
 import com.gu.pandomainauth.model.{User => PandaUser}
 
 class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  {

--- a/explainer-server/app/util/JsonConversions.scala
+++ b/explainer-server/app/util/JsonConversions.scala
@@ -1,9 +1,9 @@
 package util
 
 import com.gu.contentatom.thrift._
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 import com.gu.contentatom.thrift.atom.media.{Asset, MediaAtom}
 import com.twitter.scrooge.ThriftEnum
-import contentatom.explainer.{DisplayType, ExplainerAtom}
 import play.api.libs.functional.syntax._
 import play.api.libs.json._
 

--- a/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
+++ b/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
@@ -1,7 +1,7 @@
 package shared.models
 
 import com.gu.contentatom.thrift._
-import contentatom.explainer.{DisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.explainer.{DisplayType, ExplainerAtom}
 import shared.util.ExplainerAtomImplicits
 
 case class CsExplainerAtom(title: String, body: String, displayType: String, tags: Option[List[String]])

--- a/explainer-shared/src/main/scala/shared/util/AtomUtils.scala
+++ b/explainer-shared/src/main/scala/shared/util/AtomUtils.scala
@@ -1,7 +1,7 @@
 package shared.util
 
+import com.gu.contentatom.thrift.atom.explainer.ExplainerAtom
 import com.gu.contentatom.thrift.{Atom, AtomData, _}
-import contentatom.explainer.ExplainerAtom
 
 trait AtomDataTyper[D] {
   def getData(a: Atom): D


### PR DESCRIPTION
Previously explainers were appearing incorrectly under contentatom.explainer. Now they're in com.gu.contentatom.thrift.atom.explainer with all the other atoms.
