### PR TITLE
Introducing Commissioning Desks Management

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -52,10 +52,15 @@ object ExplainEditorJS {
     Model.extractExplainer(explainerId).map( explainer => ExplainEditorJSDomBuilders.makeTagArea(explainer).render.outerHTML )
   }
 
-  def redisplayExplainerTagManagement(explainerId: String) = {
+  def redisplayExplainerTagManagementAreas(explainerId: String) = {
     Model.extractExplainer(explainerId).map{ explainer =>
+
+      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").innerHTML = ""
+      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeCommissioningDeskArea(explainer).render)
+
       dom.document.getElementById("explainer-editor__tags-wrapper").innerHTML = ""
       dom.document.getElementById("explainer-editor__tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeTagArea(explainer).render)
+
     }
   }
 
@@ -78,25 +83,25 @@ object ExplainEditorJS {
 
   @JSExport
   def addTagToExplainer(explainerId: String, tagId: String) = {
-    Model.addTagToExplainer(explainerId, tagId).map( explainer =>
-      redisplayExplainerTagManagement(explainer.id)
-    )
+    Model.addTagToExplainer(explainerId, tagId).map { explainer =>
+      redisplayExplainerTagManagementAreas(explainer.id)
+    }
   }
 
   @JSExport
   def removeTagFromExplainer(explainerId: String, tagId: String) = {
-    Model.removeTagFromExplainer(explainerId, tagId).map( explainer =>
-      redisplayExplainerTagManagement(explainer.id)
-    )
+    Model.removeTagFromExplainer(explainerId, tagId).map { explainer =>
+      redisplayExplainerTagManagementAreas(explainer.id)
+    }
   }
 
   @JSExport
-  def addTagToSuggestionSet(explainerId: String, tagId: String) = {
-    val node = div(cls:="explainer-editor__tag-suggestion__item")(tagId).render
+  def addTagToSuggestionSet(explainerId: String, divIdentifier: String, tagId: String, userInterfaceDescription: String) = {
+    val node = div(cls:="explainer-editor__tags-common__suggestion-item")(userInterfaceDescription).render
     node.onclick = (x: Event) => {
       addTagToExplainer(explainerId, tagId)
     }
-    dom.document.getElementById("explainer-editor__tags__suggestions").appendChild(node)
+    dom.document.getElementById(divIdentifier).appendChild(node)
   }
 
 }

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -84,7 +84,7 @@ object ExplainEditorJSDomBuilders {
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.oninput = (x: Event) => {
       val searchString: String = g.readValueAtDiv("explainer-editor__tags__tag-search-input-field").asInstanceOf[String]
-      capiXMLHttpRequest("&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
+      capiXMLHttpRequest("&type=keyword&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
     }
     renderTaggingArea(explainer, "explainer-editor__tags__suggestions", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -10,6 +10,7 @@ import shared.models.{CsAtom, ExplainerUpdate}
 
 import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
+import scalatags.JsDom
 
 object ExplainEditorJSDomBuilders {
 
@@ -43,6 +44,25 @@ object ExplainEditorJSDomBuilders {
     }
   }
 
+  def renderTaggingArea(explainer:CsAtom, suggestionsDomId: String, inputTag: JsDom.Modifier, explainerToDivFilterLambda: String => Boolean) ={
+    div()(
+      div(id:="explainer-editor__tags__input-field-wrapper")(
+        div(cls:="form-group")(
+          div("")(
+            label(cls:="form-group")("Tags")
+          ),
+          div("")(
+            inputTag
+          )
+        )
+      ),
+      div(id:=suggestionsDomId, cls:="explainer-editor__tags-common__suggestions-wrapper")(""),
+      div(cls:="explainer-editor__tags-common__existing-tags-wrapper")(
+        explainerToDivTags(explainer, explainerToDivFilterLambda)
+      )
+    )
+  }
+
   def makeTagArea(explainer: CsAtom) = {
 
     val tagsSearchInput: TypedTag[Input] = input(
@@ -67,22 +87,7 @@ object ExplainEditorJSDomBuilders {
 
     }
 
-    div()(
-      div(id:="explainer-editor__tags__input-field-wrapper")(
-        div(cls:="form-group")(
-          div("")(
-            label(cls:="form-group")("Tags")
-          ),
-          div("")(
-            tagsSearchInputTag
-          )
-        )
-      ),
-      div(id:="explainer-editor__tags__suggestions", cls:="explainer-editor__tags-common__suggestions-wrapper")(""),
-      div(cls:="explainer-editor__tags-common__existing-tags-wrapper")(
-        explainerToDivTags(explainer, { tagId => !tagId.startsWith("tracking") })
-      )
-    )
+    renderTaggingArea(explainer, "explainer-editor__tags__suggestions", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
 
   }
 
@@ -109,22 +114,7 @@ object ExplainEditorJSDomBuilders {
 
     }
 
-    div()(
-      div(id:="explainer-editor__commissioning-desk-tags__input-field-wrapper")(
-        div(cls:="form-group")(
-          div("")(
-            label(cls:="form-group")("Commissioning Desks")
-          ),
-          div("")(
-            tagsSearchInputTag
-          )
-        )
-      ),
-      div(id:="explainer-editor__commissioning-desk-tags__suggestions", cls:="explainer-editor__tags-common__suggestions-wrapper")(""),
-      div(cls:="explainer-editor__tags-common__existing-tags-wrapper")(
-        explainerToDivTags(explainer, { tagId => tagId.startsWith("tracking") })
-      )
-    )
+    renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
 
   }
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -63,13 +63,13 @@ object ExplainEditorJSDomBuilders {
     )
   }
 
-  def capiXMLHttpRequest( queryFragment: String, divIdentifier: String, userInterfaceTagDescriptionKey: String ) = {
+  def capiXMLHttpRequest( queryFragment: String, divIdentifier: String, tagFieldToDisplay: String ) = {
     val xhr = new dom.XMLHttpRequest()
     xhr.open("GET", "https://content.guardianapis.com/tags?api-key="+g.CONFIG.CAPI_API_KEY+""+queryFragment+"")
     xhr.onload = (e: dom.Event) => {
       if (xhr.status == 200) {
         g.jQuery(".explainer-editor__tags-common__suggestions-wrapper").empty()
-        g.processCapiSearchResponseTags(divIdentifier,js.JSON.parse(xhr.responseText).response,userInterfaceTagDescriptionKey)
+        g.processCapiSearchResponseTags(divIdentifier,js.JSON.parse(xhr.responseText).response,tagFieldToDisplay)
       }
     }
     xhr.send()
@@ -99,7 +99,7 @@ object ExplainEditorJSDomBuilders {
     )
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.onclick = (x: Event) => {
-      capiXMLHttpRequest("&type=tracking&page-size=1000", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
+      capiXMLHttpRequest("&type=tracking&page-size=200", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
     }
     renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", "Commissioning Desk", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -63,7 +63,7 @@ object ExplainEditorJSDomBuilders {
     )
   }
 
-  def xxxxx( queryFragment: String, divIdentifier: String, userInterfaceTagDescriptionKey: String ) = {
+  def capiXMLHttpRequest( queryFragment: String, divIdentifier: String, userInterfaceTagDescriptionKey: String ) = {
     val xhr = new dom.XMLHttpRequest()
     xhr.open("GET", "https://content.guardianapis.com/tags?api-key="+g.CONFIG.CAPI_API_KEY+""+queryFragment+"")
     xhr.onload = (e: dom.Event) => {
@@ -84,7 +84,7 @@ object ExplainEditorJSDomBuilders {
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.oninput = (x: Event) => {
       val searchString: String = g.readValueAtDiv("explainer-editor__tags__tag-search-input-field").asInstanceOf[String]
-      xxxxx("&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
+      capiXMLHttpRequest("&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
     }
     renderTaggingArea(explainer, "explainer-editor__tags__suggestions", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
 
@@ -99,7 +99,7 @@ object ExplainEditorJSDomBuilders {
     )
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.onclick = (x: Event) => {
-      xxxxx("&type=tracking&page-size=1000", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
+      capiXMLHttpRequest("&type=tracking&page-size=1000", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
     }
     renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -63,57 +63,44 @@ object ExplainEditorJSDomBuilders {
     )
   }
 
-  def makeTagArea(explainer: CsAtom) = {
+  def xxxxx( queryFragment: String, divIdentifier: String, userInterfaceTagDescriptionKey: String ) = {
+    val xhr = new dom.XMLHttpRequest()
+    xhr.open("GET", "https://content.guardianapis.com/tags?api-key="+g.CONFIG.CAPI_API_KEY+""+queryFragment+"")
+    xhr.onload = (e: dom.Event) => {
+      if (xhr.status == 200) {
+        g.jQuery(".explainer-editor__tags-common__suggestions-wrapper").empty()
+        g.processCapiSearchResponseTags(divIdentifier,js.JSON.parse(xhr.responseText).response,userInterfaceTagDescriptionKey)
+      }
+    }
+    xhr.send()
+  }
 
+  def makeTagArea(explainer: CsAtom) = {
     val tagsSearchInput: TypedTag[Input] = input(
       id:="explainer-editor__tags__tag-search-input-field",
       cls:="explainer-editor__tags-common__search-input-field",
       placeholder:="tag search"
     )
-
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.oninput = (x: Event) => {
-
       val searchString: String = g.readValueAtDiv("explainer-editor__tags__tag-search-input-field").asInstanceOf[String]
-      val xhr = new dom.XMLHttpRequest()
-      xhr.open("GET", "https://content.guardianapis.com/tags?api-key="+g.CONFIG.CAPI_API_KEY+"&q="+g.encodeURIComponent(searchString))
-      xhr.onload = (e: dom.Event) => {
-        if (xhr.status == 200) {
-          g.jQuery(".explainer-editor__tags-common__suggestions-wrapper").empty()
-          g.processCapiSearchResponseGenericTags("explainer-editor__tags__suggestions",js.JSON.parse(xhr.responseText).response)
-        }
-      }
-      xhr.send()
-
+      xxxxx("&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
     }
-
     renderTaggingArea(explainer, "explainer-editor__tags__suggestions", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
 
   }
 
   def makeCommissioningDeskArea(explainer: CsAtom) = {
-
     val tagsSearchInput: TypedTag[Input] = input(
       id:="explainer-editor__commissioning-desk-tags__tag-search-input-field",
       cls:="explainer-editor__tags-common__search-input-field",
       value:="Add a commissioning desk",
       `type`:="button"
     )
-
     val tagsSearchInputTag = tagsSearchInput().render
     tagsSearchInputTag.onclick = (x: Event) => {
-      val xhr = new dom.XMLHttpRequest()
-      xhr.open("GET", "https://content.guardianapis.com/tags?api-key="+g.CONFIG.CAPI_API_KEY+"&type=tracking&page-size=1000")
-      xhr.onload = (e: dom.Event) => {
-        if (xhr.status == 200) {
-          g.jQuery(".explainer-editor__tags-common__suggestions-wrapper").empty()
-          g.processCapiSearchResponseCommissioningDesk("explainer-editor__commissioning-desk-tags__suggestions",js.JSON.parse(xhr.responseText).response)
-        }
-      }
-      xhr.send()
-
+      xxxxx("&type=tracking&page-size=1000", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
     }
-
     renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
 
   }

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -44,12 +44,12 @@ object ExplainEditorJSDomBuilders {
     }
   }
 
-  def renderTaggingArea(explainer:CsAtom, suggestionsDomId: String, inputTag: JsDom.Modifier, explainerToDivFilterLambda: String => Boolean) ={
+  def renderTaggingArea(explainer:CsAtom, suggestionsDomId: String, fieldDescription:String, inputTag: JsDom.Modifier, explainerToDivFilterLambda: String => Boolean) ={
     div()(
       div(id:="explainer-editor__tags__input-field-wrapper")(
         div(cls:="form-group")(
           div("")(
-            label(cls:="form-group")("Tags")
+            label(cls:="form-group")(fieldDescription)
           ),
           div("")(
             inputTag
@@ -86,7 +86,7 @@ object ExplainEditorJSDomBuilders {
       val searchString: String = g.readValueAtDiv("explainer-editor__tags__tag-search-input-field").asInstanceOf[String]
       capiXMLHttpRequest("&type=keyword&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
     }
-    renderTaggingArea(explainer, "explainer-editor__tags__suggestions", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
+    renderTaggingArea(explainer, "explainer-editor__tags__suggestions", "Tags", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
 
   }
 
@@ -101,7 +101,7 @@ object ExplainEditorJSDomBuilders {
     tagsSearchInputTag.onclick = (x: Event) => {
       capiXMLHttpRequest("&type=tracking&page-size=1000", "explainer-editor__commissioning-desk-tags__suggestions", "webTitle")
     }
-    renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
+    renderTaggingArea(explainer, "explainer-editor__commissioning-desk-tags__suggestions", "Commissioning Desk", tagsSearchInputTag, { tagId => tagId.startsWith("tracking") })
 
   }
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -30,20 +30,20 @@ object ExplainEditorJSDomBuilders {
     status
   }
 
-  def makeTagArea(explainer: CsAtom) = {
-
-    def explainerToDivTags(explainer:CsAtom) = {
-      explainer.data.tags match {
-        case None => List()
-        case Some(list) => list.filter( tagId => !tagId.startsWith("tracking") ).map(tagId => div(cls:="explainer-editor__tags-common__existing-tag")(
-          span(
-            cls:="explainer-editor__tags-common__tag-delete-icon",
-            data("explainer-id"):=explainer.id,
-            data("tag-id"):=tagId
-          )("[x]")," ",tagId
-        ))
-      }
+  def explainerToDivTags(explainer:CsAtom, filterLambda: String => Boolean) = {
+    explainer.data.tags match {
+      case None => List()
+      case Some(list) => list.filter( tagId => filterLambda(tagId) ).map(tagId => div(cls:="explainer-editor__tags-common__existing-tag")(
+        span(
+          cls:="explainer-editor__tags-common__tag-delete-icon",
+          data("explainer-id"):=explainer.id,
+          data("tag-id"):=tagId
+        )("[x]")," ",tagId
+      ))
     }
+  }
+
+  def makeTagArea(explainer: CsAtom) = {
 
     val tagsSearchInput: TypedTag[Input] = input(
       id:="explainer-editor__tags__tag-search-input-field",
@@ -80,26 +80,13 @@ object ExplainEditorJSDomBuilders {
       ),
       div(id:="explainer-editor__tags__suggestions", cls:="explainer-editor__tags-common__suggestions-wrapper")(""),
       div(cls:="explainer-editor__tags-common__existing-tags-wrapper")(
-        explainerToDivTags(explainer)
+        explainerToDivTags(explainer, { tagId => !tagId.startsWith("tracking") })
       )
     )
 
   }
 
   def makeCommissioningDeskArea(explainer: CsAtom) = {
-
-    def explainerToDivTags(explainer:CsAtom) = {
-      explainer.data.tags match {
-        case None => List()
-        case Some(list) => list.filter( tagId => tagId.startsWith("tracking") ).map(tagId => div(cls:="explainer-editor__tags-common__existing-tag")(
-          span(
-            cls:="explainer-editor__tags-common__tag-delete-icon",
-            data("explainer-id"):=explainer.id,
-            data("tag-id"):=tagId
-          )("[x]")," ",tagId
-        ))
-      }
-    }
 
     val tagsSearchInput: TypedTag[Input] = input(
       id:="explainer-editor__commissioning-desk-tags__tag-search-input-field",
@@ -135,7 +122,7 @@ object ExplainEditorJSDomBuilders {
       ),
       div(id:="explainer-editor__commissioning-desk-tags__suggestions", cls:="explainer-editor__tags-common__suggestions-wrapper")(""),
       div(cls:="explainer-editor__tags-common__existing-tags-wrapper")(
-        explainerToDivTags(explainer)
+        explainerToDivTags(explainer, { tagId => tagId.startsWith("tracking") })
       )
     )
 

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -43,6 +43,13 @@ function updateCheckboxState() {
  * Tag Search
  */
 
+
+function processCapiSearchResponseTags(divIdentifier,response,userInterfaceTagDescriptionKey){
+    response.results.forEach(function(tag){
+        ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,divIdentifier,tag.id,tag[userInterfaceTagDescriptionKey]);
+    });
+}
+
 function processCapiSearchResponseGenericTags(divIdentifier,response){
     response.results.forEach(function(tag){
         ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,divIdentifier,tag.id,tag.id);

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -43,13 +43,19 @@ function updateCheckboxState() {
  * Tag Search
  */
 
-function processCapiSearchResponse(response){
+function processCapiSearchResponseGenericTags(divIdentifier,response){
     response.results.forEach(function(tag){
-        ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,tag.id);
+        ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,divIdentifier,tag.id,tag.id);
     });
 }
 
-$(document).delegate( ".explainer-editor__tags__existing-tags__tag-delete-icon", "click", function() {
+function processCapiSearchResponseCommissioningDesk(divIdentifier,response){
+    response.results.forEach(function(tag){
+        ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,divIdentifier,tag.id,tag.webTitle);
+    });
+}
+
+$(document).delegate( ".explainer-editor__tags-common__tag-delete-icon", "click", function() {
     var explainerId = $(this).data("explainer-id");
     var tagId = $(this).data("tag-id");
     ExplainEditorJS().removeTagFromExplainer(explainerId,tagId);

--- a/explainer-server/public/stylesheets/explainer.css
+++ b/explainer-server/public/stylesheets/explainer.css
@@ -180,10 +180,6 @@ h2, h3, h4, h5, h6, .preview__title, .preview__score {
             padding: 6px;
         }
 
-    .explainer-editor__tags__input-field-label {
-        font-family: bold;
-    }
-
     #explainer-editor__body-wrapper {
 
     }
@@ -220,40 +216,38 @@ h2, h3, h4, h5, h6, .preview__title, .preview__score {
 
             }
 
+
 /* -------------------------------------- */
-/* Explainer Tags                         */
+/* Tags Common Elements                   */
 /* -------------------------------------- */
 
+.explainer-editor__tags-common__suggestion-item {
+    color:blue;
+    font-weight: bold;
+    padding-left:30px;
+    cursor: pointer;
+    cursor: hand;
+}
 
-    .explainer-editor__tags__input-field-label {
+.explainer-editor__tags-common__tag-delete-icon {
+    cursor: pointer;
+    cursor: hand;
+    color:red;
+}
 
-    }
+.explainer-editor__tags-common__existing-tag {
 
-    .explainer-editor__tags__suggestions {
-        margin-top:20px;
-    }
+}
 
-        .explainer-editor__tag-suggestion__item {
-            color:blue;
-            font-weight: bold;
-            padding-left:30px;
-            cursor: pointer;
-            cursor: hand;
-        }
+.explainer-editor__tags-common__existing-tags-wrapper {
+    padding-top:20px;
+    padding-left:30px;
+}
 
-    .explainer-editor__tags__existing-tags {
-        padding-top:20px;
-        padding-left:30px;
-    }
+.explainer-editor__tags-common__search-input-field {
+    width:300px;
+}
 
-        .explainer-editor__tags__existing-tags__tag-delete-icon {
-            cursor: pointer;
-            cursor: hand;
-            color:red;
-        }
-        .explainer-editor__tags__existing-tags__tag {
-
-        }
-
-
-
+.explainer-editor__tags-common__suggestions-wrapper {
+    margin-top:20px;
+}


### PR DESCRIPTION
This brings the management of the commissioning desks.

The backend has not changed because all tags are (still) stored by their ids.

The front end now has a new tag searching area generated by `makeCommissioningDeskArea`
which only searched and displays tracking tags.

Also, some improvements in the CSS of tags related elements (see updates in explainer.css).
