### PR TITLE
Switch to content atom lib database layer to store explainers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
   routesImport += "config.Routes._",
   scalaJSProjects := clients,
   pipelineStages := Seq(scalaJSProd, gzip),
-  resolvers += "scalaz-bintray" at "https://dl.bintray.com/scalaz/releases",
+  resolvers ++= Seq("scalaz-bintray" at "https://dl.bintray.com/scalaz/releases", Resolver.sonatypeRepo("snapshots")),
   libraryDependencies ++= Seq(
     filters,
     "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
@@ -35,7 +35,7 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
     "org.webjars" % "jquery" % "2.1.4",
     "org.webjars" % "font-awesome" % "4.4.0",
     "org.webjars" % "tinymce" % "4.2.1",
-    "com.gu" %% "atom-publisher-lib" % "0.1.2",
+    "com.gu" %% "atom-publisher-lib" % "0.1.3-SNAPSHOT",
     "com.twitter" %% "scrooge-core" % "4.5.0",
     "com.gu" %% "scanamo-scrooge" % "0.1.2",
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
   libraryDependencies ++= Seq(
     filters,
     "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
-    "com.gu" %% "scanamo" % "0.6.1-SNAPSHOT",
+    "com.gu" %% "scanamo" % "0.6.0",
     ws, // for panda
     "com.gu" %% "pan-domain-auth-verification" % "0.3.0",
     "com.vmunier" %% "play-scalajs-scripts" % "0.3.0",
@@ -35,9 +35,9 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
     "org.webjars" % "jquery" % "2.1.4",
     "org.webjars" % "font-awesome" % "4.4.0",
     "org.webjars" % "tinymce" % "4.2.1",
-    "com.gu" %% "atom-publisher-lib" % "1.0.0-SNAPSHOT",
+    "com.gu" %% "atom-publisher-lib" % "0.1.2",
     "com.twitter" %% "scrooge-core" % "4.5.0",
-    "com.gu" %% "scanamo-scrooge" % "0.1.2-SNAPSHOT",
+    "com.gu" %% "scanamo-scrooge" % "0.1.2",
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
     "com.gu" % "kinesis-logback-appender" % "1.2.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.2"

--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
   libraryDependencies ++= Seq(
     filters,
     "com.amazonaws" % "aws-java-sdk-core" % awsVersion,
-    "com.gu" %% "scanamo" % "0.6.0",
+    "com.gu" %% "scanamo" % "0.6.1-SNAPSHOT",
     ws, // for panda
     "com.gu" %% "pan-domain-auth-verification" % "0.3.0",
     "com.vmunier" %% "play-scalajs-scripts" % "0.3.0",
@@ -35,9 +35,9 @@ lazy val explainMakerServer = (project in file("explainer-server")).enablePlugin
     "org.webjars" % "jquery" % "2.1.4",
     "org.webjars" % "font-awesome" % "4.4.0",
     "org.webjars" % "tinymce" % "4.2.1",
-    "com.gu" %% "atom-publisher-lib" % "0.1.1",
+    "com.gu" %% "atom-publisher-lib" % "1.0.0-SNAPSHOT",
     "com.twitter" %% "scrooge-core" % "4.5.0",
-    "com.gu" %% "scanamo-scrooge" % "0.1.1",
+    "com.gu" %% "scanamo-scrooge" % "0.1.2-SNAPSHOT",
     "com.amazonaws" % "aws-java-sdk-ec2" % awsVersion,
     "com.gu" % "kinesis-logback-appender" % "1.2.0",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.2"

--- a/cloud-formation/dynamo-prod.json.template
+++ b/cloud-formation/dynamo-prod.json.template
@@ -1,0 +1,8 @@
+{
+  "AWSTemplateFormatVersion" : "2010-09-09",
+
+  "Description" : "",
+
+  "Resources" : {
+  }
+}

--- a/explainer-server/app/config/Config.scala
+++ b/explainer-server/app/config/Config.scala
@@ -5,9 +5,10 @@ import javax.inject.{Inject, Singleton}
 import com.amazonaws.auth.{AWSCredentialsProviderChain, InstanceProfileCredentialsProvider}
 import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
 import com.amazonaws.services.kinesis.AmazonKinesisClient
 import play.api.Configuration
-import services.{AWS, AwsInstanceTags}
+import services.AwsInstanceTags
 
 @Singleton
 class Config @Inject() (conf: Configuration) extends AwsInstanceTags {
@@ -48,6 +49,12 @@ class Config @Inject() (conf: Configuration) extends AwsInstanceTags {
 
   lazy val kinesisClient = region.createClient(
     classOf[AmazonKinesisClient],
+    awsCredentialsprovider,
+    null
+  )
+
+  val dynamoClient = region.createClient(
+    classOf[AmazonDynamoDBClient],
     awsCredentialsprovider,
     null
   )

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -83,7 +83,7 @@ class ExplainerApiImpl(
           tags = Some((tagId +: csatom.data.tags.getOrElse(List())).distinct.sorted)
         )
       )
-      explainerDB.store(CsAtom.csAtomToAtom(newCsAtom))
+      explainerDB.update(CsAtom.csAtomToAtom(newCsAtom))
       explainerStore.updateLastModified(explainerId, user)
     }
     load(explainerId)
@@ -99,7 +99,7 @@ class ExplainerApiImpl(
           }
         )
       )
-      explainerDB.store(CsAtom.csAtomToAtom(newCsAtom))
+      explainerDB.update(CsAtom.csAtomToAtom(newCsAtom))
       explainerStore.updateLastModified(explainerId, user)
     }
     load(explainerId)

--- a/explainer-server/app/db/ExplainerDB.scala
+++ b/explainer-server/app/db/ExplainerDB.scala
@@ -3,68 +3,42 @@ package db
 import javax.inject.Inject
 
 import cats.data.Xor
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
-import com.gu.contentatom.thrift.Atom
-import com.gu.scanamo.error.{DynamoReadError, TypeCoercionError}
-import com.gu.scanamo.{DynamoFormat, Scanamo, ScanamoAsync}
+import com.gu.contentatom.thrift._
 import config.Config
-import com.gu.scanamo.{Table, _}
-import com.gu.scanamo.syntax._
 import com.gu.scanamo.scrooge.ScroogeDynamoFormat._
-import com.twitter.scrooge.CompactThriftSerializer
-import play.api.Logger
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
+import com.gu.atom.data.DynamoDataStore
+import contentatom.explainer.ExplainerAtom
+
 
 class ExplainerDB @Inject() (config: Config) {
 
-  implicit def seqFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Seq[T]] =
-    DynamoFormat.xmap[Seq[T], List[T]](l => Xor.right(l.toSeq))(_.toList)
-
-  // you can't use BinaryThriftStructSerializer from crooge-serializer
-  // if Thrift is greater than 0.9.0 as they use a method that has
-  // been removed (see https://github.com/twitter/scrooge/issues/203)
-  // Also the JsonThriftserializer is one way only (it doesn't store
-  // the Thrift type data because it uses the TSimpleJsonProtocol)
-
-  private val atomSerializer = CompactThriftSerializer(Atom)
-
-  private def rowToAtom(row: AtomRow): Xor[DynamoReadError, Atom] = try {
-    Xor.Right(atomSerializer.fromString(row.atom))
-  } catch {
-    case err: org.apache.thrift.TException => Xor.Left(TypeCoercionError(err))
+  val dynamoDataStore = new DynamoDataStore[ExplainerAtom](config.dynamoClient, config.tableName) {
+    def fromAtomData = { case AtomData.Explainer(data) => data }
+    def toAtomData(data: ExplainerAtom) = AtomData.Explainer(data)
   }
 
-  case class AtomRow(id: String, atom: String)
 
-  object AtomRow {
-    def apply(atom: Atom): AtomRow = AtomRow(
-      atom.id, atomSerializer.toString(atom)
-    )
+  def create(explainer: Atom) = {
+    dynamoDataStore.createAtom(explainer)
   }
-
-  implicit val dynamoFormat: DynamoFormat[Atom] =
-    DynamoFormat.xmap(rowToAtom _)(AtomRow.apply _)(DynamoFormat[AtomRow]) // <- just saving a new implicit here
-
-  val dynamoDBClient: AmazonDynamoDBAsyncClient = new AmazonDynamoDBAsyncClient(config.awsCredentialsprovider).withRegion(config.region)
-  val explainersTable  = Table[Atom](config.tableName)
 
   def store(explainer: Atom): Unit = {
-    Scanamo.put(dynamoDBClient)(config.tableName)(explainer)
+    dynamoDataStore.updateAtom(explainer)
   }
 
   def all : Future[Seq[Atom]] = {
-    ScanamoAsync.scan[Atom](dynamoDBClient)(config.tableName).map(_.flatMap(_.toOption))
+    Future(dynamoDataStore.listAtoms match {
+      case Xor.Right(atoms) => atoms.toSeq
+      case _ => Nil
+    })
   }
 
   def load(id: String): Future[Atom] = {
-    val operations = for {
-      explainer <- explainersTable.get('id -> id)
-    } yield {
-      explainer
-    }
-    ScanamoAsync.exec(dynamoDBClient)(operations).map(_.flatMap(_.toOption).get)
+    Future(dynamoDataStore.getAtom(id).get)
+
   }
 
 }

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -69,7 +69,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
         data = AtomData.Explainer(newExplainerAtom),
         contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updateCreated = false, updateLastModified = true, updatePublished = false)
       )
-      explainerDB.store(updatedExplainer)
+      explainerDB.update(updatedExplainer)
       updatedExplainer
     }
   }
@@ -79,7 +79,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
       val contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updateCreated = false, updateLastModified = true, updatePublished = false)
       val updatedExplainer = buildAtomWithDefaults(explainer.id, explainer.tdata , contentChangeDetails)
 
-      explainerDB.store(updatedExplainer)
+      explainerDB.update(updatedExplainer)
       updatedExplainer
     }
   }
@@ -89,7 +89,6 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     val explainerAtom = ExplainerAtom("", "", DisplayType.Expandable)
     val contentChangeDetails = contentChangeDetailsBuilder(user, None, updateCreated = true, updateLastModified = true, updatePublished = false)
     val explainer = buildAtomWithDefaults(uuid, explainerAtom, contentChangeDetails)
-    explainerDB.store(explainer)
     explainerDB.create(explainer)
     Future(explainer)
   }
@@ -98,7 +97,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     explainerDB.load(id).map{ explainer =>
       val contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updateCreated = false, updateLastModified = false, updatePublished = true)
       val updatedExplainer = buildAtomWithDefaults(explainer.id, explainer.tdata, contentChangeDetails)
-      explainerDB.store(updatedExplainer)
+      explainerDB.update(updatedExplainer)
       updatedExplainer
     }
   }

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -23,7 +23,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     Atom(
       id = id,
       atomType = AtomType.Explainer,
-      defaultHtml = "",
+      defaultHtml = "-",
       data = AtomData.Explainer(explainerAtom),
       contentChangeDetails = contentChangeDetails
     )
@@ -78,6 +78,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     explainerDB.load(id).map{ explainer =>
       val contentChangeDetails = contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updateCreated = false, updateLastModified = true, updatePublished = false)
       val updatedExplainer = buildAtomWithDefaults(explainer.id, explainer.tdata , contentChangeDetails)
+
       explainerDB.store(updatedExplainer)
       updatedExplainer
     }
@@ -89,6 +90,7 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     val contentChangeDetails = contentChangeDetailsBuilder(user, None, updateCreated = true, updateLastModified = true, updatePublished = false)
     val explainer = buildAtomWithDefaults(uuid, explainerAtom, contentChangeDetails)
     explainerDB.store(explainer)
+    explainerDB.create(explainer)
     Future(explainer)
   }
 


### PR DESCRIPTION
The main change here is that explainers will be stored in dynamo as their individual fields rather than as a big lump of thrift. This is good because it means we can now e.g. sort by creation date.

This re-introduces the problem of having title/body as an empty string, so I've added conversion functions in ExplainerDB to deal with this.
