### PR TITLE
re-enablying tag management

### DIFF
--- a/explainer-client/src/main/scala/Ajaxer.scala
+++ b/explainer-client/src/main/scala/Ajaxer.scala
@@ -43,11 +43,11 @@ object Model {
   }
 
   def addTagToExplainer(explainerId: String, tagId: String): Future[CsAtom] = {
-    Ajaxer[ExplainerApi].addTagToExplainer(explainerId, tagId).call()
+    Ajaxer[ExplainerApi].update(explainerId, "addTag", tagId).call()
   }
 
   def removeTagFromExplainer(explainerId: String, tagId: String): Future[CsAtom] = {
-    Ajaxer[ExplainerApi].removeTagFromExplainer(explainerId, tagId).call()
+    Ajaxer[ExplainerApi].update(explainerId, "removeTag", tagId).call()
   }
 
 }

--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -52,18 +52,6 @@ object ExplainEditorJS {
     Model.extractExplainer(explainerId).map( explainer => ExplainEditorJSDomBuilders.makeTagArea(explainer).render.outerHTML )
   }
 
-  def redisplayExplainerTagManagementAreas(explainerId: String) = {
-    Model.extractExplainer(explainerId).map{ explainer =>
-
-      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").innerHTML = ""
-      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeCommissioningDeskArea(explainer).render)
-
-      dom.document.getElementById("explainer-editor__tags-wrapper").innerHTML = ""
-      dom.document.getElementById("explainer-editor__tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeTagArea(explainer).render)
-
-    }
-  }
-
   @JSExport
   def CreateNewExplainer() = {
     Model.createNewExplainer().map{ explainer: CsAtom =>
@@ -84,14 +72,14 @@ object ExplainEditorJS {
   @JSExport
   def addTagToExplainer(explainerId: String, tagId: String) = {
     Model.addTagToExplainer(explainerId, tagId).map { explainer =>
-      redisplayExplainerTagManagementAreas(explainer.id)
+      ExplainEditorJSDomBuilders.redisplayExplainerTagManagementAreas(explainer.id)
     }
   }
 
   @JSExport
   def removeTagFromExplainer(explainerId: String, tagId: String) = {
     Model.removeTagFromExplainer(explainerId, tagId).map { explainer =>
-      redisplayExplainerTagManagementAreas(explainer.id)
+      ExplainEditorJSDomBuilders.redisplayExplainerTagManagementAreas(explainer.id)
     }
   }
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -63,7 +63,7 @@ object ExplainEditorJSDomBuilders {
       case None => List()
       case Some(list) => list.filter( tagId => filterLambda(tagId) ).map(tagId => {
         div(cls:="tag")(
-            " ",tagId,tagDeleteButton(explainer,tagId)
+            tagId,tagDeleteButton(explainer,tagId)
           )
         }
       )

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -31,17 +31,42 @@ object ExplainEditorJSDomBuilders {
     status
   }
 
+  def redisplayExplainerTagManagementAreas(explainerId: String): Unit = {
+    Model.extractExplainer(explainerId).map{ explainer =>
+
+      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").innerHTML = ""
+      dom.document.getElementById("explainer-editor__commissioning-desk-tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeCommissioningDeskArea(explainer).render)
+
+      dom.document.getElementById("explainer-editor__tags-wrapper").innerHTML = ""
+      dom.document.getElementById("explainer-editor__tags-wrapper").appendChild(ExplainEditorJSDomBuilders.makeTagArea(explainer).render)
+
+    }
+  }
+
+  def tagDeleteButton(explainer:CsAtom, tagId:String) = {
+    val deleteButton = button(
+      cls:="tag__delete",
+      `type`:="button",
+      data("explainer-id"):=explainer.id,
+      data("tag-id"):=tagId
+    )("Delete").render
+    deleteButton.onclick = (x: Event) => {
+      Model.removeTagFromExplainer(explainer.id, tagId).map { explainer =>
+        redisplayExplainerTagManagementAreas(explainer.id)
+      }
+    }
+    deleteButton
+  }
+
   def explainerToDivTags(explainer:CsAtom, filterLambda: String => Boolean) = {
     explainer.data.tags match {
       case None => List()
-      case Some(list) => list.filter( tagId => filterLambda(tagId) ).map(tagId => div(cls:="tag")(
-        " ",tagId,button(
-          cls:="tag__delete",
-          `type`:="button",
-          data("explainer-id"):=explainer.id,
-          data("tag-id"):=tagId
-        )("Delete")
-      ))
+      case Some(list) => list.filter( tagId => filterLambda(tagId) ).map(tagId => {
+        div(cls:="tag")(
+            " ",tagId,tagDeleteButton(explainer,tagId)
+          )
+        }
+      )
     }
   }
 

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -90,7 +90,6 @@ object ExplainEditorJSDomBuilders {
       capiXMLHttpRequest("&type=keyword&q="+g.encodeURIComponent(searchString), "explainer-editor__tags__suggestions", "id")
     }
     renderTaggingArea(explainer, "explainer-editor__tags__suggestions", "Tags", tagsSearchInputTag, { tagId => !tagId.startsWith("tracking") })
-
   }
 
   def makeCommissioningDeskArea(explainer: CsAtom) = {

--- a/explainer-server/app/controllers/ApiController.scala
+++ b/explainer-server/app/controllers/ApiController.scala
@@ -76,35 +76,6 @@ class ExplainerApiImpl(
     explainerToPublish.map(CsAtom.atomToCsAtom)
   }
 
-  override def addTagToExplainer(explainerId: String, tagId: String): Future[CsAtom] = {
-    explainerDB.load(explainerId).map(CsAtom.atomToCsAtom).map{ csatom =>
-      val newCsAtom = csatom.copy(
-        data = csatom.data.copy(
-          tags = Some((tagId +: csatom.data.tags.getOrElse(List())).distinct.sorted)
-        )
-      )
-      explainerDB.update(CsAtom.csAtomToAtom(newCsAtom))
-      explainerStore.updateLastModified(explainerId, user)
-    }
-    load(explainerId)
-  }
-
-  override def removeTagFromExplainer(explainerId: String, tagId: String): Future[CsAtom] = {
-    explainerDB.load(explainerId).map(CsAtom.atomToCsAtom).map{ csatom =>
-      val newCsAtom: CsAtom = csatom.copy(
-        data = csatom.data.copy(
-          tags = csatom.data.tags.flatMap{ list =>
-            val newlist = (list diff List(tagId)).sorted
-            if(newlist.isEmpty){ None }else{ Some(newlist) }
-          }
-        )
-      )
-      explainerDB.update(CsAtom.csAtomToAtom(newCsAtom))
-      explainerStore.updateLastModified(explainerId, user)
-    }
-    load(explainerId)
-  }
-
 }
 
 class ApiController @Inject() (val config: Config,

--- a/explainer-server/app/db/ExplainerDB.scala
+++ b/explainer-server/app/db/ExplainerDB.scala
@@ -31,7 +31,6 @@ class ExplainerDB @Inject() (config: Config) extends ExplainerAtomImplicits {
         body = conversionFunction(explainer.tdata.body))))
   }
 
-
   def create(explainer: Atom) = {
     val sanitisedAtom = emptyStringConversion(explainer, emptyStringToEmptyStringMarker)
     dynamoDataStore.createAtom(sanitisedAtom)

--- a/explainer-server/app/models/ExplainerStore.scala
+++ b/explainer-server/app/models/ExplainerStore.scala
@@ -51,7 +51,9 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
     val allowed_fields = Set(
       "title",
       "body",
-      "displayType"
+      "displayType",
+      "addTag",
+      "removeTag"
     )
     assert(allowed_fields.contains(fieldSymbol.name))
     explainerDB.load(id).map{ explainer =>
@@ -64,6 +66,11 @@ class ExplainerStore @Inject() (config: Config) extends ExplainerAtomImplicits  
             case "Flat" => explainer.tdata.copy( displayType = DisplayType.Flat )
           }
         }
+        case "addTag" => explainer.tdata.copy(tags = Some((value +: explainer.tdata.tags.getOrElse(List())).distinct.sorted))
+        case "removeTag" => explainer.tdata.copy(tags = explainer.tdata.tags.flatMap(tagList => {
+          val newTagList = (tagList diff List(value)).sorted
+          if(newTagList.isEmpty){ None }else{ Some(newTagList) }
+        }))
       }
       val updatedExplainer = explainer.copy(
         data = AtomData.Explainer(newExplainerAtom),

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -45,7 +45,6 @@ function updateCheckboxState() {
  * Tag Search
  */
 
-
 function processCapiSearchResponseTags(divIdentifier,response,userInterfaceTagDescriptionKey){
     response.results.forEach(function(tag){
         ExplainEditorJS().addTagToSuggestionSet(EXPLAINER_IDENTIFIER,divIdentifier,tag.id,tag[userInterfaceTagDescriptionKey]);

--- a/explainer-shared/src/main/scala/shared/ExplainerApi.scala
+++ b/explainer-shared/src/main/scala/shared/ExplainerApi.scala
@@ -16,7 +16,4 @@ trait ExplainerApi {
    */
   def publish(id: String): Future[CsAtom]
 
-  def addTagToExplainer(explainerId: String, tagId: String): Future[CsAtom]
-  def removeTagFromExplainer(explainerId: String, tagId: String): Future[CsAtom]
-
 }


### PR DESCRIPTION
Fixes a bug in the backend by which atom version numbers where not correctly updated. And also update the UI to add an handler to the new tag trash icon
