### PR TITLE
More info in explainer list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Explainer Atom Editor
 
 * CI : [TeamCity](https://teamcity-aws.gutools.co.uk/viewType.html?buildTypeId=EditorialTools_Explainer)
+* See live: [PROD](https://explainers.gutools.co.uk) [CODE](https://explainers.code.dev-gutools.co.uk)
 
 ###Scala: 2.11.6, Scala.js: 0.6.5, Play: 2.4.0, Slick: 3.0.0
 

--- a/explainer-client/src/main/scala/example/ExampleJS.scala
+++ b/explainer-client/src/main/scala/example/ExampleJS.scala
@@ -6,7 +6,7 @@ import shared.SharedMessages
 
 object ExampleJS extends js.JSApp {
   def main(): Unit = {
-    g.console.log(SharedMessages.itWorks)
+
   }
 
   /** Computes the square of an integer.

--- a/explainer-server/app/util/HelperFunctions.scala
+++ b/explainer-server/app/util/HelperFunctions.scala
@@ -1,0 +1,22 @@
+package util
+
+import com.gu.contentatom.thrift.Atom
+
+
+object HelperFunctions {
+  def getCreatedByString(explainer: Atom) = {
+    val firstNameLastName = for {
+      created <- explainer.contentChangeDetails.created
+      user <- created.user
+      firstName <- user.firstName
+      lastName <- user.lastName
+    } yield {
+      s"$firstName $lastName"
+    }
+    firstNameLastName.getOrElse("-")
+  }
+
+  def isPublished(explainer: Atom) = {
+    if(explainer.contentChangeDetails.published.isDefined) "Published" else "Draft"
+  }
+}

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -2,6 +2,7 @@
 @import shared.util.ExplainerAtomImplicits
 @import org.joda.time.DateTime
 @import org.joda.time.format.DateTimeFormat
+@import util.HelperFunctions._
 
 @(explainers: Seq[Atom], user: com.gu.pandomainauth.model.AuthenticatedUser)(implicit request: RequestHeader)
 
@@ -11,10 +12,6 @@
             <a class="top-toolbar__title" href="/">
                 <div class="top-toolbar__logo"></div>
                 <div class="top-toolbar__page-icon"></div>
-                <div class="top-toolbar__title__hover-state">
-                    <span class="top-toolbar__title__hover-state__subtitle">Back to</span><br />
-                    <span class="top-toolbar__title__hover-state__title">Dashboard</span>
-                </div>
             </a>
         </div>
         <div class="top-toolbar__container">
@@ -58,8 +55,8 @@
                             val fmt = DateTimeFormat.forPattern("MM/dd/YYYY HH:MM");
                             fmt.print(datetime);
                         }</td>
-                        <td class="explainer-list__item">-</td>
-                        <td class="explainer-list__item">-</td>
+                        <td class="explainer-list__item">@{getCreatedByString(e)}</td>
+                        <td class="explainer-list__item">@{isPublished(e)}</td>
                     </tr>
                 }
             </table>


### PR DESCRIPTION
Show who created an explainer on the main list. Also remove the on hover 'back to dashboard' text when already on the dashboard.

![screen shot 2016-08-11 at 12 24 14](https://cloud.githubusercontent.com/assets/3606555/17587194/934e89d4-5fbe-11e6-945e-1502c65ab585.png)
