### PR TITLE
Pass through correct name of title field to update, use separate label for title

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -190,7 +190,8 @@ object ExplainEditorJSDomBuilders {
 
     form()(
       div(cls:="form-row")(
-        ExplainEditorPresenceHelpers.turnOnPresenceFor(explainerId,"Title",titleTag)
+          div(cls:="form-label")("Explainer Title"),
+          titleTag
       ),
       div(cls:="form-row")(
         div(cls:="form-label")("Interactive URL"),

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -151,7 +151,7 @@ object ExplainEditorJSDomBuilders {
 
     val titleTag = title(value := explainer.data.title).render
     titleTag.onchange = (x: Event) => {
-      Model.updateFieldContent(explainerId, ExplainerUpdate("Explainer Title", titleTag.value)).map(republishStatusBar)
+      Model.updateFieldContent(explainerId, ExplainerUpdate("title", titleTag.value)).map(republishStatusBar)
     }
 
     val interactiveBaseUrl = g.CONFIG.INTERACTIVE_URL.toString


### PR DESCRIPTION
This separates the label string from that used to determine which field is updated
