### PR TITLE
Dynamic display of the interactive URL section

### DIFF
--- a/explainer-client/src/main/scala/ExplainEditorJS.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJS.scala
@@ -20,6 +20,7 @@ object ExplainEditorJS {
     })
 
     Model.extractExplainer(explainerId).map { explainer: CsAtom =>
+
       dom.document.getElementById("content").appendChild(
         ExplainEditorJSDomBuilders.ExplainEditor(explainerId, explainer)
       )

--- a/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
+++ b/explainer-client/src/main/scala/ExplainEditorJSDomBuilders.scala
@@ -188,16 +188,18 @@ object ExplainEditorJSDomBuilders {
     checkboxTag.onchange = (x: Event) => {
       g.updateCheckboxState()
     }
+    
+    val interactiveURLWrapperDisplay = explainer.contentChangeDetails.published match {
+      case Some(thing) => div(cls:="form-row")( div(cls:="form-label")("Interactive URL"), interactiveUrlTag )
+      case None => div()("")
+    }
 
     form()(
       div(cls:="form-row")(
           div(cls:="form-label")("Explainer Title"),
           titleTag
       ),
-      div(cls:="form-row")(
-        div(cls:="form-label")("Interactive URL"),
-        interactiveUrlTag
-      ),
+      interactiveURLWrapperDisplay,
       div(cls:="form-row")(
         div()(
           checkboxTag, " Expandable explainer"


### PR DESCRIPTION
Do not display the interactive URL section in the side bar when explainer has never been published

This small change prevents the display of the interactive URL when
the explainer has never been published. To do so it looks up the value of
`explainer.contentChangeDetails.published`
