### PR TITLE
Enablying Pagination

### DIFF
--- a/explainer-client/src/main/scala/ExplainListJS.scala
+++ b/explainer-client/src/main/scala/ExplainListJS.scala
@@ -8,18 +8,10 @@ import scala.scalajs.js.URIUtils
 @JSExport
 object ExplainListJS {
 
-  def insertParam(key: String, value: String): Unit = {
+  def replaceParams(key: String, value: String): Unit = {
     val keyEnc = URIUtils.encodeURI(key)
     val valueEnc = URIUtils.encodeURI(value)
-
-    val parameters = dom.document.location.search.substring(1).split('&').map(p => {
-      if (p.startsWith(keyEnc)) {
-        s"$keyEnc=$valueEnc"
-      } else p
-    }).mkString("&")
-    val newQueryString = if (!parameters.contains(keyEnc)) s"$parameters&$keyEnc=$valueEnc" else parameters
-
-    dom.document.location.search = newQueryString
+    dom.document.location.search = s"$keyEnc=$valueEnc"
   }
 
   @JSExport
@@ -31,7 +23,7 @@ object ExplainListJS {
       val urlWithoutQueryParameters = s"${dom.document.location.protocol}//${dom.document.location.host}${dom.document.location.pathname}"
       dom.document.location.assign(urlWithoutQueryParameters)
     } else {
-      insertParam("desk", selectedDesk)
+      replaceParams("desk", selectedDesk)
     }
   }
 }

--- a/explainer-server/app/controllers/ExplainEditorController.scala
+++ b/explainer-server/app/controllers/ExplainEditorController.scala
@@ -20,6 +20,37 @@ import services.CAPIService
 
 import scala.util.{Failure, Success}
 
+
+object DeskStringUtilities {
+  def deskToQueryStringWithTrailingAmpersand(desk: Option[String]): String = {
+    desk match {
+      case Some(tag) => s"desk=${tag}&"
+      case None => ""
+    }
+  }
+}
+
+object Paginator {
+  val pageSize: Int = 12
+  def previousFragment(desk:Option[String], pageNumber: Int): String = {
+    if(pageNumber>1){
+      " | <a href=\"/?" +DeskStringUtilities.deskToQueryStringWithTrailingAmpersand(desk)+ "pageNumber=" + (pageNumber-1).toString() + "\">previous</a>"
+    }else{
+      ""
+    }
+  }
+  def nextFragment(desk:Option[String], pageNumber: Int, maxPageNumber: Int): String = {
+    if(pageNumber<maxPageNumber){
+      " | <a href=\"?" +DeskStringUtilities.deskToQueryStringWithTrailingAmpersand(desk)+ "pageNumber=" + (pageNumber+1).toString() + "\">next</a>"
+    }else{
+      ""
+    }
+  }
+  def maxPageNumber(numberOfExplainers: Int): Int = {
+    (numberOfExplainers.toFloat/pageSize).toInt+1
+  }
+}
+
 class ExplainEditorController @Inject() (val publicSettingsService: PublicSettingsService, config: Config, cache: CacheApi) extends Controller with AuthActions with ExplainerAtomImplicits {
 
   val pandaAuthenticated = new PandaAuthenticated(config)
@@ -32,27 +63,45 @@ class ExplainEditorController @Inject() (val publicSettingsService: PublicSettin
       "INTERACTIVE_URL" -> config.interactiveUrl,
       "PRESENCE_ENDPOINT_URL" -> config.presenceEndpointURL
     )
-
     explainerDB.load(id).map(e => {
       Ok(views.html.explainEditor(e,request.user,viewConfig))
     })
   }
 
-  def listExplainers(desk: Option[String]) = pandaAuthenticated.async{ implicit request =>
+  def listExplainers(desk: Option[String], maybePageNumber: Option[Int]) = pandaAuthenticated.async{ implicit request =>
+
+    val pageNumber: Int = maybePageNumber.getOrElse(1)
+
     def sorting(e1: Atom, e2: Atom): Boolean = {
       val time1:Long = e1.contentChangeDetails.lastModified.map(_.date).getOrElse(0)
       val time2:Long = e2.contentChangeDetails.lastModified.map(_.date).getOrElse(0)
       time1 > time2
     }
 
+    def selectPageExplainers(explainers: Seq[Atom], pageNumber: Int, pageSize: Int) = {
+      // Here we drop pageNumber*pageSize and then keep the next pageSize elements.
+      explainers.drop((pageNumber-1)*pageSize).take(pageSize)
+    }
+
     val result = for {
       explainers <- explainerDB.all
       trackingTags <- capiService.getTrackingTags
     } yield {
-      val explainersForDesk = desk.fold(explainers)(d => explainers.filter(_.tdata.tags.exists(_.contains(d))))
-      val trackingTagsWithAssociatedExplainer = trackingTags.filter(t => explainers.flatMap(_.tdata.tags.getOrElse(Seq())).distinct.contains(t.id))
 
-      Ok(views.html.explainList(explainersForDesk.sortWith(sorting), request.user, trackingTagsWithAssociatedExplainer, desk))
+      val trackingTagsWithAssociatedExplainers = trackingTags.filter(t => explainers.flatMap(_.tdata.tags.getOrElse(Seq())).distinct.contains(t.id))
+
+      val explainersForDesk = desk.fold(explainers)(d => explainers.filter(_.tdata.tags.exists(_.contains(d))))
+      val explainersWithSorting = explainersForDesk.sortWith(sorting)
+      val explainersForPage = selectPageExplainers(explainersWithSorting,pageNumber,Paginator.pageSize)
+
+      // Pagination
+
+      val maxPageNumber: Int = Paginator.maxPageNumber(explainersWithSorting.length)
+      val previousFragmentHTML: String = Paginator.previousFragment(desk,pageNumber)
+      val nextFragmentHTML: String = Paginator.nextFragment(desk,pageNumber,maxPageNumber)
+
+      Ok(views.html.explainList(explainersForPage, request.user, trackingTagsWithAssociatedExplainers, desk, pageNumber, previousFragmentHTML, nextFragmentHTML))
+
     }
     result.recover{ case err =>
       Logger.error("Error fetching explainers from dynamo", err)

--- a/explainer-server/app/controllers/ExplainEditorController.scala
+++ b/explainer-server/app/controllers/ExplainEditorController.scala
@@ -47,7 +47,11 @@ object Paginator {
     }
   }
   def maxPageNumber(numberOfExplainers: Int): Int = {
-    (numberOfExplainers.toFloat/pageSize).toInt+1
+    if (numberOfExplainers % pageSize == 0){
+      (numberOfExplainers.toFloat/pageSize).toInt
+    }else{
+      (numberOfExplainers.toFloat/pageSize).toInt+1
+    }
   }
 }
 

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -7,7 +7,7 @@
 @import com.gu.contentapi.client.model.v1.Tag
 @import scala.concurrent.ExecutionContext.Implicits.global
 
-@(explainers: Seq[Atom], user: com.gu.pandomainauth.model.AuthenticatedUser, trackingTags: Seq[Tag], desk: Option[String])(implicit request: RequestHeader)
+@(explainers: Seq[Atom], user: com.gu.pandomainauth.model.AuthenticatedUser, trackingTags: Seq[Tag], desk: Option[String], pageNumber: Int, previousFragmentHTML: String, nextFragmentHTML: String)(implicit request: RequestHeader)
 
 @toolbar = {
     <header class="top-toolbar">
@@ -57,7 +57,7 @@
                     <tr class="explainer-list__row">
                         <td class="explainer-list__item">
                             <a class="explainer-list__link" href="/explain/@e.id">@{if(ExplainerAtomImplicits.AtomWithData(e).tdata.title.trim.length>0){
-                            ExplainerAtomImplicits.AtomWithData(e).tdata.title
+                                ExplainerAtomImplicits.AtomWithData(e).tdata.title
                             }else{
                                 "untitled"
                             }}</a>
@@ -73,6 +73,9 @@
                     </tr>
                 }
             </table>
+            <div class="pagination" style="text-align:center;margin:10px 0px 0px 0px;">
+                Page @{pageNumber} @Html(previousFragmentHTML)@Html(nextFragmentHTML)
+            <div>
         </div>
     </div>
 }

--- a/explainer-server/conf/routes
+++ b/explainer-server/conf/routes
@@ -3,7 +3,7 @@
 # ~~~~
 
 # Home page
-GET           /                            controllers.ExplainEditorController.listExplainers(desk: Option[String])
+GET           /                            controllers.ExplainEditorController.listExplainers(desk: Option[String], pageNumber: Option[Int])
 GET           /healthcheck                 controllers.Healthcheck.healthcheck
 
 GET           /explain/:id                 controllers.ExplainEditorController.get(id)


### PR DESCRIPTION
Here we enable pagination for the Dashboard. A pagination that is compatible with desk filtering.

**URLs**:

Page 1 of the dashboard (all desks): 
`https://explainers.local.dev-gutools.co.uk/`

Page 2 of the dashboard (all desks): 
`https://explainers.local.dev-gutools.co.uk/?pageNumber=2`

Page 1 of the dashboard with filtering on `tracking/commissioningdesk/au-masterclasses`
`https://explainers.local.dev-gutools.co.uk/?desk=tracking/commissioningdesk/au-masterclasses`

Page 2 of the dashboard with filtering on `tracking/commissioningdesk/au-masterclasses`
`https://explainers.local.dev-gutools.co.uk/?desk=tracking/commissioningdesk/au-masterclasses&pageNumber=2`

Note that the url always puts the desk tagId (if presents) in first position of the query string.

**Paginator**:

Simple page:

![screen shot 2016-08-26 at 16 17 47](https://cloud.githubusercontent.com/assets/6035518/18010496/a9b96658-6ba8-11e6-9aae-b4d071ae56d6.png)

Page 1 with `next` link

![screen shot 2016-08-26 at 16 18 14](https://cloud.githubusercontent.com/assets/6035518/18010512/be945b78-6ba8-11e6-9927-ab558e9fb966.png)

Page 2 with `previous` and `next`

![screen shot 2016-08-26 at 16 19 25](https://cloud.githubusercontent.com/assets/6035518/18010556/e87068e2-6ba8-11e6-8b42-9c3eb46a2c8a.png)

Last page:

![screen shot 2016-08-26 at 16 22 04](https://cloud.githubusercontent.com/assets/6035518/18010642/3f7f2998-6ba9-11e6-9845-93f5f8bcc539.png)
