### PR TITLE
Update in the display of the word count overflow warning

### DIFF
--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -51,7 +51,7 @@
             <div class="top-toolbar__item">
                 <p class="top-toolbar__item-inner word-count">
                     <span class="word-count__number"></span>
-                    <span class="word-count__message">Max word count exceeded</span>
+                    <span id="word-count__message" class="word-count__message label--important"></span>
                 </p>
             </div>
             <div class="top-toolbar__item">

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -9,17 +9,19 @@ function getBodyWordCount(){
     }
     return trimmedInnerText.split(" ").length;
 }
-const maxWordCount = 150;
+const maxWordCount = 100;
 function updateWordCountDisplay() {
     var count = getBodyWordCount(),
         sentence = ( count===0 || count>1 ) ? count+" words" : count+" word";
     $(".word-count__number").text(sentence)
 }
 function updateWordCountWarningDisplay() {
-    if (getBodyWordCount() > maxWordCount) {
+    if ( (getBodyWordCount()>maxWordCount) && $("#expandable").is(':checked') ) {
         $(".word-count__message").show();
+        $(".word-count__message").text("Too long for flat explainer");
     } else {
         $(".word-count__message").hide();
+        $(".word-count__message").text("");
     }
 }
 function updateStatusBar(message){
@@ -90,6 +92,7 @@ function updateCheckboxState() {
     } else {
         ExplainEditorJS().setDisplayType(EXPLAINER_IDENTIFIER,"Flat")
     }
+    updateWordCountWarningDisplay();
 };
 
 /*

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -16,7 +16,7 @@ function updateWordCountDisplay() {
     $(".word-count__number").text(sentence)
 }
 function updateWordCountWarningDisplay() {
-    if ( (getBodyWordCount()>maxWordCount) && $("#expandable").is(':checked') ) {
+    if ( (getBodyWordCount()>maxWordCount) && !$("#expandable").is(':checked') ) {
         $(".word-count__message").show();
         $(".word-count__message").text("Too long for flat explainer");
     } else {

--- a/explainer-server/public/stylesheets/scss/components/_messages.scss
+++ b/explainer-server/public/stylesheets/scss/components/_messages.scss
@@ -23,3 +23,7 @@
   color: #FFF;
   background: #47af37;
 }
+
+.label--important {
+  color: #FF1E20;
+}


### PR DESCRIPTION
In this commit.
1. The limit for overflow has been set to 100 words.
2. Above 100 words (and only if the explainer is set to `flat`)
   we display "Too long for flat explainer" in red.
3. The display is dynamic in the sense that toggling the expandable
   explainer flag updates the warning accordingly.
