### PR TITLE
Add preview link, rename to 'text atoms'

### DIFF
--- a/explainer-client/src/main/scala/components/Sidebar.scala
+++ b/explainer-client/src/main/scala/components/Sidebar.scala
@@ -20,13 +20,15 @@ import scala.scalajs.js.Dynamic.{global => g}
 
 object Sidebar {
 
+  val embedUrlString = s"${g.CONFIG.INTERACTIVE_URL.toString}?id=${g.CONFIG.EXPLAINER_IDENTIFIER.toString}"
+
   def title(explainer:CsAtom) = {
 
     import scala.concurrent.ExecutionContext.Implicits.global
     val titleInput  = input(
       id:="explainer-editor__title-wrapper__input",
       cls:="form-field",
-      placeholder:="Explainer Title",
+      placeholder:="Text Atom Title",
       autofocus:=true
     )(value := explainer.data.title).render
 
@@ -38,7 +40,7 @@ object Sidebar {
 
   def embedUrlBox(embedUrlText: String) =
     div(cls:="form-row")(
-      div(cls:="form-label")("Embed URL"),
+      div(cls:="form-label")("Embed URL ", span(id:="embed-preview-link", cls:="preview-link")(a(href:=embedUrlString, target:="_blank")("Preview"))),
       textarea(
         id:="interactive-url-text",
         cls:="form-field form-field--text-area text-monospaced",
@@ -48,13 +50,30 @@ object Sidebar {
     )
 
   def embedUrlText(explainerId: String, status:PublicationStatus) = status match {
-    case Available | UnlaunchedChanges => s"${g.CONFIG.INTERACTIVE_URL.toString}?id=$explainerId"
-    case Draft => "Publish explainer to get embed URL."
-    case TakenDown => "The explainer has been taken down. Republish to get URL."
+    case Available | UnlaunchedChanges => embedUrlString
+    case Draft => "Publish text atom to get embed URL."
+    case TakenDown => "The text atom has been taken down. Republish to get URL."
+  }
+
+  def updatePreviewLink(status: PublicationStatus, embedUrl: String) ={
+    val interactivePreviewLink = dom.document.getElementById("embed-preview-link")
+    status match {
+
+      case Available | UnlaunchedChanges => {
+        interactivePreviewLink.asInstanceOf[Span].classList.remove("preview-link--hidden")
+        interactivePreviewLink.asInstanceOf[Span].classList.add("preview-link")
+      }
+      case _ => {
+        interactivePreviewLink.asInstanceOf[Span].classList.remove("preview-link")
+        interactivePreviewLink.asInstanceOf[Span].classList.add("preview-link--hidden")
+      }
+    }
   }
 
   def republishembedURL(explainerId: String, status: PublicationStatus = Available) = {
-    dom.document.getElementById("interactive-url-text").textContent = embedUrlText(explainerId, status)
+    val urlText = embedUrlText(explainerId, status)
+    updatePreviewLink(status, urlText)
+    dom.document.getElementById("interactive-url-text").textContent = urlText
   }
 
   def displayTypeToggle(displayType: String, checkboxId: String) = {
@@ -85,12 +104,12 @@ object Sidebar {
     val checkboxId = "expandable"
     form()(
       div(cls:="form-row")(
-        div(cls:="form-label")("Explainer Title"),
+        div(cls:="form-label")("Text Atom Title"),
         title(explainer)
       ),
       embedUrlBox(embedUrlText(explainer.id, status)),
       div(cls:="form-row")(
-        p(cls:="form-label")("Expandable Explainer"),
+        p(cls:="form-label")("Expandable Text Atom"),
         div(cls:="form-checkbox")(
           displayTypeToggle(explainer.data.displayType, checkboxId),
           label(

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -67,7 +67,7 @@ class ExplainerApiImpl(
         contentChangeDetails=contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updatePublished = true)
       )
       explainerDB.update(updatedExplainer)
-      sendKinesisEvent(updatedExplainer, s"Publishing explainer $updatedExplainer.id} to LIVE kinesis", liveAtomPublisher)
+      sendKinesisEvent(updatedExplainer, s"Publishing explainer ${updatedExplainer.id} to LIVE kinesis", liveAtomPublisher)
       CsAtom.atomToCsAtom(updatedExplainer)
     }
   }

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -54,7 +54,7 @@
 @main("Explainers", toolbar){
     <div class="container block-center">
         <div id="dashboard" class="explainer-list">
-            <h1>Explainers</h1>
+            <h1>Text Atoms</h1>
             <table class="explainer-list__table">
                 <tr>
                     <th class="explainer-list__header">Title</th>

--- a/explainer-server/public/stylesheets/scss/layout/_sidebar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_sidebar.scss
@@ -11,3 +11,12 @@
   height: calc(100vh - #{$toolbarHeight});
   overflow: auto;
 }
+
+.preview-link {
+  display: inline;
+  color: $c-blue-link;
+
+  &--hidden {
+    display: none;
+  }
+}


### PR DESCRIPTION
This will make it easier for people to preview explainers. Screenshot:
![screen shot 2016-09-13 at 17 22 51](https://cloud.githubusercontent.com/assets/3606555/18482111/c2a05f00-79d6-11e6-9196-b1694e7114b3.png)
