### PR TITLE
Update explainerDB in accordance with changes made to atom lib. 

### DIFF
--- a/cloud-formation/explain-maker.cf.json
+++ b/cloud-formation/explain-maker.cf.json
@@ -172,7 +172,12 @@
                         "Effect": "Allow",
                         "Action": [ "dynamodb:*" ],
                         "Resource": [ { "Fn::Join": [ "", [ "arn:aws:dynamodb:eu-west-1:743583969668:table/explain-maker-preview-", { "Ref": "Stage" } ] ] } ]
-                      }
+                      },
+                        {
+                            "Effect": "Allow",
+                            "Action": [ "dynamodb:*" ],
+                            "Resource": [ { "Fn::Join": [ "", [ "arn:aws:dynamodb:eu-west-1:743583969668:table/explain-maker-live-", { "Ref": "Stage" } ] ] } ]
+                        }
                     ]
                   }
                 },

--- a/explainer-server/app/config/Config.scala
+++ b/explainer-server/app/config/Config.scala
@@ -69,6 +69,7 @@ class Config @Inject() (conf: Configuration) extends AwsInstanceTags {
     null
   )
 
-  val tableName = s"explain-maker-preview-$stage"
+  val previewTableName = s"explain-maker-preview-$stage"
+  val liveTableName = s"explain-maker-live-$stage"
 
 }

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -67,6 +67,7 @@ class ExplainerApiImpl(
         contentChangeDetails=contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updatePublished = true)
       )
       explainerDB.update(updatedExplainer)
+      explainerDB.publish(updatedExplainer)
       sendKinesisEvent(updatedExplainer, s"Publishing explainer ${updatedExplainer.id} to LIVE kinesis", liveAtomPublisher)
       CsAtom.atomToCsAtom(updatedExplainer)
     }
@@ -78,6 +79,7 @@ class ExplainerApiImpl(
         contentChangeDetails=contentChangeDetailsBuilder(user, Some(explainer.contentChangeDetails), updateLastModified = true)
       )
       explainerDB.update(updatedExplainer)
+      explainerDB.takeDown(updatedExplainer)
       sendKinesisEvent(updatedExplainer, s"Sending takedown event for explainer ${updatedExplainer.id} to LIVE kinesis.", liveAtomPublisher, EventType.Takedown)
       CsAtom.atomToCsAtom(updatedExplainer)
     })


### PR DESCRIPTION
Also, add takeDown and publish functions which add/remove from the live table.

This should fix the problems with master no longer compiling, make reindexing more sensible (when that's implemented), and save us from hitting capi to work out whether something has been taken down or not.
