### PR TITLE
Add status indicators to content

### DIFF
--- a/cloud-formation/dynamo-prod.json.template
+++ b/cloud-formation/dynamo-prod.json.template
@@ -17,6 +17,14 @@
             "Description": "Code live dynamo table name",
             "Type": "String"
         },
+        "ProdWorkflowDataTableName": {
+            "Description": "Prod workflow data table name",
+            "Type": "String"
+        },
+        "CodeWorkflowDataTableName": {
+            "Description": "Code workflow data table name",
+            "Type": "String"
+        },
         "ProdReadWriteCapacity":{
             "Description": "Prod Read/Write Capacity",
             "Type": "String"
@@ -97,6 +105,50 @@
             "Type": "AWS::DynamoDB::Table",
             "Properties": {
                 "TableName": { "Ref": "CodeLiveTableName" },
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "id",
+                        "AttributeType": "S"
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": "id",
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": { "Ref": "CodeReadWriteCapacity" },
+                    "WriteCapacityUnits": { "Ref": "CodeReadWriteCapacity"}
+                }
+            }
+        },
+        "ExplainMakerProdWorkflowDataDynamoTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "TableName": { "Ref": "ProdWorkflowDataTableName" },
+                "AttributeDefinitions": [
+                    {
+                        "AttributeName": "id",
+                        "AttributeType": "S"
+                    }
+                ],
+                "KeySchema": [
+                    {
+                        "AttributeName": "id",
+                        "KeyType": "HASH"
+                    }
+                ],
+                "ProvisionedThroughput": {
+                    "ReadCapacityUnits": { "Ref": "ProdReadWriteCapacity" },
+                    "WriteCapacityUnits": { "Ref": "ProdReadWriteCapacity" }
+                }
+            }
+        },
+        "ExplainMakerCodeWorkflowDataDynamoTable": {
+            "Type": "AWS::DynamoDB::Table",
+            "Properties": {
+                "TableName": { "Ref": "CodeWorkflowDataTableName" },
                 "AttributeDefinitions": [
                     {
                         "AttributeName": "id",

--- a/cloud-formation/explain-maker.cf.json
+++ b/cloud-formation/explain-maker.cf.json
@@ -177,6 +177,11 @@
                             "Effect": "Allow",
                             "Action": [ "dynamodb:*" ],
                             "Resource": [ { "Fn::Join": [ "", [ "arn:aws:dynamodb:eu-west-1:743583969668:table/explain-maker-live-", { "Ref": "Stage" } ] ] } ]
+                        },
+                        {
+                            "Effect": "Allow",
+                            "Action": [ "dynamodb:*" ],
+                            "Resource": [ { "Fn::Join": [ "", [ "arn:aws:dynamodb:eu-west-1:743583969668:table/explain-maker-workflow-data-", { "Ref": "Stage" } ] ] } ]
                         }
                     ]
                   }

--- a/explainer-client/src/main/scala/api/Ajaxer.scala
+++ b/explainer-client/src/main/scala/api/Ajaxer.scala
@@ -7,7 +7,7 @@ import rx._
 import shared.ExplainerApi
 import shared.models.PublicationStatus.PublicationStatus
 import shared.models.UpdateField.{AddTag, RemoveTag}
-import shared.models.{CsAtom, ExplainerUpdate}
+import shared.models.{CsAtom, ExplainerUpdate, WorkflowData}
 
 import scala.concurrent.Future
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
@@ -50,6 +50,14 @@ object Model {
 
   def getExplainerStatus(explainerId: String, checkCapiStatus: Boolean): Future[PublicationStatus] = {
     Ajaxer[ExplainerApi].getStatus(explainerId, checkCapiStatus).call()
+  }
+
+  def getWorkflowData(id: String): Future[WorkflowData] = {
+    Ajaxer[ExplainerApi].getWorkflowData(id).call()
+  }
+
+  def setWorkflowData(workflowData: WorkflowData) = {
+    Ajaxer[ExplainerApi].setWorkflowData(workflowData).call()
   }
 
 }

--- a/explainer-client/src/main/scala/components/Sidebar.scala
+++ b/explainer-client/src/main/scala/components/Sidebar.scala
@@ -3,7 +3,7 @@ package components
 import api.Model
 import org.scalajs.dom._
 import org.scalajs.dom.html._
-import shared.models.{CsAtom, ExplainerUpdate}
+import shared.models.{PublicationStatus => _, _}
 
 import scala.scalajs.js.Dynamic._
 import scala.util.{Failure, Success}
@@ -13,6 +13,7 @@ import org.scalajs.dom
 import services.State
 import shared.models.PublicationStatus._
 import shared.models.UpdateField.{Body, Title}
+import shared.models.WorkflowStatus._
 import shared.util.SharedHelperFunctions
 import views.ExplainEditor
 
@@ -53,6 +54,27 @@ object Sidebar {
     case Available | UnlaunchedChanges => embedUrlString
     case Draft => "Publish text atom to get embed URL."
     case TakenDown => "The text atom has been taken down. Republish to get URL."
+  }
+
+  def statusToOption(status: WorkflowStatus, currentStatus: WorkflowStatus) = {
+    val opt = option(value:= status.toString)(status.toString).render
+    opt.selected = status == currentStatus
+    opt
+  }
+
+  def wfStatusOptions(currentStatus: WorkflowStatus) = {
+    List(statusToOption(Writers, currentStatus), statusToOption(Desk, currentStatus), statusToOption(Subs, currentStatus), statusToOption(Live, currentStatus))
+  }
+
+  def workflowStatusDropdown(id: String, currentStatus: WorkflowStatus) = {
+    val dropdown = select(cls := "workflow-status-select")(wfStatusOptions(currentStatus)).render
+    dropdown.onchange = (x:Event) => {
+      Model.setWorkflowData(WorkflowData(id, WorkflowStatus(dropdown.value)))
+    }
+    div(cls:="form-row")(
+      div(cls:="form-label")("Status"),
+      dropdown
+    )
   }
 
   def updatePreviewLink(status: PublicationStatus, embedUrl: String) ={
@@ -100,7 +122,7 @@ object Sidebar {
     checkboxTag
   }
 
-  def sidebar(explainer: CsAtom, status: PublicationStatus) = {
+  def sidebar(explainer: CsAtom, status: PublicationStatus, workflowStatus: WorkflowStatus) = {
     val checkboxId = "expandable"
     form()(
       div(cls:="form-row")(
@@ -118,6 +140,7 @@ object Sidebar {
           )
         )
       ),
+      workflowStatusDropdown(explainer.id, workflowStatus),
       div(cls:="explainer-editor__tag-management-wrapper")(
         div(
           id:="explainer-editor__commissioning-desk-tags-wrapper",

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -31,19 +31,25 @@ object ExplainEditor {
       })
     }
 
-    Model.getExplainer(explainerId).map { explainer: CsAtom =>
+    val explainer =  Model.getExplainer(explainerId)
 
+    explainer.map { explainer =>
       dom.document.getElementById("content").appendChild(
         ScribeBodyEditor.renderedBodyEditor(explainer)
-      )
+    )
+  }
 
+    for {
+      e <- explainer
+      wfData <- Model.getWorkflowData(explainerId)
+    } yield {
       getStatus(explainerId).map(s => {
         if (s == TakenDown) State.takenDown = true
         dom.document.getElementById("sidebar").appendChild(
-          Sidebar.sidebar(explainer, s)
+          Sidebar.sidebar(e, s, wfData.status)
         )
         updateEmbedUrlAndStatusLabel(explainerId, s)
-        })
+      })
       callback()
     }
   }

--- a/explainer-server/app/config/Config.scala
+++ b/explainer-server/app/config/Config.scala
@@ -71,5 +71,6 @@ class Config @Inject() (conf: Configuration) extends AwsInstanceTags {
 
   val previewTableName = s"explain-maker-preview-$stage"
   val liveTableName = s"explain-maker-live-$stage"
+  val workflowDataTableName = s"explain-maker-workflow-data-$stage"
 
 }

--- a/explainer-server/app/controllers/ExplainEditorController.scala
+++ b/explainer-server/app/controllers/ExplainEditorController.scala
@@ -50,6 +50,8 @@ class ExplainEditorController @Inject() (val publicSettingsService: PublicSettin
       explainers <- explainerDB.all
       trackingTags <- capiService.getTrackingTags
     } yield {
+      val workflowData = explainerDB.getWorkflowData(explainers.map(_.id).toList)
+      val statusMap = workflowData.map(d => (d.id, d.status)).toMap
 
       val trackingTagsInUse = trackingTags.filter(t => explainers.flatMap(_.tdata.tags.getOrElse(Seq())).distinct.contains(t.id))
 
@@ -59,7 +61,7 @@ class ExplainEditorController @Inject() (val publicSettingsService: PublicSettin
 
       val paginationConfig = Paginator.getPaginationConfig(pageNumber, desk, explainersWithSorting)
 
-      Ok(views.html.explainList(explainersForPage, request.user.user, trackingTagsInUse, desk, paginationConfig))
+      Ok(views.html.explainList(explainersForPage, request.user.user, trackingTagsInUse, desk, paginationConfig, statusMap))
 
     }
     result.recover{ case err =>

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -14,7 +14,7 @@ import db.ExplainerDB
 import models.{PublishResult, Disabled => PublishDisabled, Fail => PublishFail, Success => PublishSuccess}
 import services.{CAPIService, PublicSettingsService}
 import shared.ExplainerApi
-import shared.models.{CsAtom, ExplainerUpdate}
+import shared.models.{CsAtom, ExplainerUpdate, WorkflowData}
 import shared.util.ExplainerAtomImplicits._
 import com.gu.pandomainauth.model.{User => PandaUser}
 import shared.models.PublicationStatus._
@@ -90,6 +90,14 @@ class ExplainerApiImpl(
       e <- explainerDB.load(id)
       s <- getExplainerStatus(e, capiService, checkCapiStatus, config.stage)
     } yield s
+  }
+
+  override def getWorkflowData(id:String): WorkflowData = {
+    explainerDB.getWorkflowData(id)
+  }
+
+  override def setWorkflowData(workflowData: WorkflowData) = {
+    explainerDB.setWorkflowData(workflowData)
   }
 
   private def sendKinesisEvent(explainer: Atom, actionMessage: String, atomPublisher: AtomPublisher, eventType: EventType = EventType.Update): PublishResult = {

--- a/explainer-server/app/db/ExplainerDB.scala
+++ b/explainer-server/app/db/ExplainerDB.scala
@@ -95,5 +95,9 @@ class ExplainerDB @Inject() (config: Config) extends ExplainerAtomImplicits {
     exec(workflowDataTable.put(workflowData))
   }
 
+  def getWorkflowData(ids: List[String]) = {
+    exec(workflowDataTable.getAll('id -> ids)).map(_.getOrElse(None)).asInstanceOf[List[WorkflowData]]
+  }
+
 
 }

--- a/explainer-server/app/db/ExplainerDB.scala
+++ b/explainer-server/app/db/ExplainerDB.scala
@@ -12,8 +12,12 @@ import com.gu.atom.data.{PreviewDynamoDataStore, PublishedDynamoDataStore}
 import com.gu.contentatom.thrift.atom.explainer._
 import shared.util.ExplainerAtomImplicits
 import com.gu.atom.data.ScanamoUtil._
+import com.gu.scanamo.ops.ScanamoOps
+import com.gu.scanamo.query.UniqueKeys
 import com.gu.scanamo.syntax._
 import com.gu.scanamo.{DynamoFormat, Scanamo, Table}
+import shared.models.{WorkflowData, WorkflowStatus}
+import util.HelperFunctions
 
 
 class ExplainerDB @Inject() (config: Config) extends ExplainerAtomImplicits {
@@ -71,6 +75,24 @@ class ExplainerDB @Inject() (config: Config) extends ExplainerAtomImplicits {
 
   def takeDown(explainer: Atom) = {
     Scanamo.delete(config.dynamoClient)(config.liveTableName)('id -> explainer.id)
+  }
+
+  implicit val workflowStatusFormat = DynamoFormat.coercedXmap[WorkflowStatus, String, IllegalArgumentException](
+    WorkflowStatus(_))(_.toString)
+
+  val workflowDataTable = Table[WorkflowData](config.workflowDataTableName)
+  def exec[A](ops: ScanamoOps[A]): A = Scanamo.exec(config.dynamoClient)(ops)
+
+  def getWorkflowData(id: String): WorkflowData = {
+    val defaultData = WorkflowData(id)
+    exec(workflowDataTable.get('id -> id)).fold(defaultData)({
+      case Xor.Right(data) => data
+      case _ => defaultData
+    })
+  }
+
+  def setWorkflowData(workflowData: WorkflowData) = {
+    exec(workflowDataTable.put(workflowData))
   }
 
 

--- a/explainer-server/app/util/HelperFunctions.scala
+++ b/explainer-server/app/util/HelperFunctions.scala
@@ -1,7 +1,7 @@
 package util
 
 import com.gu.contentatom.thrift.{ChangeRecord, _}
-import com.gu.contentatom.thrift.atom.explainer.{DisplayType =>ThriftDisplayType, ExplainerAtom}
+import com.gu.contentatom.thrift.atom.explainer.{ExplainerAtom, DisplayType => ThriftDisplayType}
 import org.joda.time.DateTime
 import services.CAPIService
 import shared.models.PublicationStatus._

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -7,9 +7,10 @@
 @import scala.concurrent.ExecutionContext.Implicits.global
 @import com.gu.pandomainauth.model.User
 @import util.PaginationConfig
+@import shared.models.WorkflowStatus
 
 @(explainers: Seq[Atom], user: User, trackingTags: Seq[Tag], desk: Option[String],
-        paginationConfig: PaginationConfig)(implicit request: RequestHeader)
+        paginationConfig: PaginationConfig, statusMap: Map[String, WorkflowStatus])(implicit request: RequestHeader)
 
 @toolbar = {
     <header class="top-toolbar">
@@ -60,7 +61,8 @@
                     <th class="explainer-list__header">Title</th>
                     <th class="explainer-list__header">Last modified</th>
                     <th class="explainer-list__header">Created by</th>
-                    <th class="explainer-list__header">Status</th>
+                    <th class="explainer-list__header">Publication status</th>
+                    <th class="explainer-list__header">Workflow status</th>
                 </tr>
                 @for(e <- explainers) {
                     <tr class="explainer-list__row">
@@ -79,6 +81,7 @@
                         }</td>
                         <td class="explainer-list__item">@{getCreatedByString(e)}</td>
                         <td class="explainer-list__item">@{isPublished(e)}</td>
+                        <td class="explainer-list__item">@{statusMap.getOrElse(e.id, "Unknown status")}</td>
                     </tr>
                 }
             </table>

--- a/explainer-shared/src/main/scala/shared/ExplainerApi.scala
+++ b/explainer-shared/src/main/scala/shared/ExplainerApi.scala
@@ -1,6 +1,6 @@
 package shared
 
-import shared.models.{CsAtom, ExplainerUpdate}
+import shared.models.{CsAtom, ExplainerUpdate, WorkflowData}
 import shared.models.PublicationStatus.PublicationStatus
 
 import scala.concurrent.Future
@@ -14,5 +14,8 @@ trait ExplainerApi {
   def publish(id: String): Future[CsAtom]
   def takeDown(id: String): Future[CsAtom]
   def getStatus(id: String, checkCapiStatus: Boolean): Future[PublicationStatus]
+
+  def getWorkflowData(id:String): WorkflowData
+  def setWorkflowData(workflowData: WorkflowData)
 
 }

--- a/explainer-shared/src/main/scala/shared/models/WorkflowData.scala
+++ b/explainer-shared/src/main/scala/shared/models/WorkflowData.scala
@@ -1,0 +1,18 @@
+package shared.models
+
+sealed trait WorkflowStatus
+case object Writers extends WorkflowStatus
+case object Desk extends WorkflowStatus
+case object Subs extends WorkflowStatus
+case object Live extends WorkflowStatus
+
+object WorkflowStatus {
+  def apply(s: String): WorkflowStatus =  s match {
+    case "Writers" => Writers
+    case "Desk" => Desk
+    case "Subs" => Subs
+    case "Live" => Live
+  }
+}
+
+case class WorkflowData(id: String, status: WorkflowStatus = Writers)


### PR DESCRIPTION
Long term, we think it might be nice to track atoms in workflow. But in the short term this is a quicker solution to monitoring the production flow of these things.

We're using a new table for this so as to keep the main table purely atom data that capi cares about. My hope is that eventually any data that capi doesn't care about could be stored in capi.
