### PR TITLE
Add custom vcl

### DIFF
--- a/explainers-api-custom-vcl.vcl
+++ b/explainers-api-custom-vcl.vcl
@@ -1,0 +1,7 @@
+sub vcl_recv {
+#FASTLY recv
+if (server.identity ~ "LCY$") {
+      set req.http.Host = "content.guardianapis.com";
+}
+
+}


### PR DESCRIPTION
For the interactive fastly config - the only thing that is changed here is that we change the request host if we're in london. 
