### PR TITLE
Add authentication to fastly purging, purge on takedown, wait 5s to allow capi to update.

### DIFF
--- a/explainer-client/src/main/scala/components/Sidebar.scala
+++ b/explainer-client/src/main/scala/components/Sidebar.scala
@@ -3,6 +3,7 @@ package components
 import api.Model
 import org.scalajs.dom._
 import org.scalajs.dom.html._
+import org.scalajs.dom.html.Anchor
 import shared.models._
 
 import scala.scalajs.js.Dynamic._
@@ -15,6 +16,7 @@ import shared.models.UpdateField.{Body, Title}
 import shared.models.WorkflowStatus._
 import shared.util.SharedHelperFunctions
 import views.ExplainEditor
+
 
 import scala.scalajs.js.Dynamic.{global => g}
 
@@ -40,7 +42,7 @@ object Sidebar {
 
   def embedUrlBox(embedUrlText: String) =
     div(cls:="form-row")(
-      div(cls:="form-label")("Embed URL ", span(id:="embed-preview-link", cls:="preview-link")(a(href:=embedUrlString, target:="_blank")("Preview"))),
+      div(cls:="form-label")("Embed URL ", a(id:="embed-preview-link", cls:="simple-link preview-link", href:=embedUrlString, target:="_blank")("Preview")),
       textarea(
         id:="interactive-url-text",
         cls:="form-field form-field--text-area text-monospaced",
@@ -81,12 +83,10 @@ object Sidebar {
     status match {
 
       case Available | UnlaunchedChanges => {
-        interactivePreviewLink.asInstanceOf[Span].classList.remove("preview-link--hidden")
-        interactivePreviewLink.asInstanceOf[Span].classList.add("preview-link")
+        interactivePreviewLink.asInstanceOf[Anchor].classList.remove("visually-hidden")
       }
       case _ => {
-        interactivePreviewLink.asInstanceOf[Span].classList.remove("preview-link")
-        interactivePreviewLink.asInstanceOf[Span].classList.add("preview-link--hidden")
+        interactivePreviewLink.asInstanceOf[Anchor].classList.add("visually-hidden")
       }
     }
   }
@@ -124,7 +124,6 @@ object Sidebar {
   def sidebar(explainer: CsAtom, status: PublicationStatus, workflowStatus: WorkflowStatus) = {
     val checkboxId = "expandable"
     form()(
-      span(cls:="text-atom-guide-link")(a(href:="https://docs.google.com/document/d/1-o4kOXINgsxxotUYlkEoyqcwnJLrtc54Nv7m2S3l_7c/edit?ts=57e13f8a", target:="_blank")("Text Atom Guide")),
       div(cls:="form-row")(
         div(cls:="form-label")("Text Atom Title"),
         title(explainer)

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -66,7 +66,7 @@ object ExplainEditor {
   def updateEmbedUrlAndStatusLabel(id: String, status: PublicationStatus) = {
     // show spinner for 4s to allow fastly cache to purge
     setTimeout(4000) {
-      dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.remove("publication-state--loading")
+      dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.remove("state-indicator--loading")
     }
     StatusBar.updateStatusBar(status)
     Sidebar.republishembedURL(id, status)
@@ -74,7 +74,7 @@ object ExplainEditor {
 
   @JSExport
   def publish(explainerId: String) = {
-    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("publication-state--loading")
+    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("state-indicator--loading")
     Model.publish(explainerId) onComplete {
       case Success(_) =>
         State.takenDown = false
@@ -85,7 +85,7 @@ object ExplainEditor {
 
   @JSExport
   def takeDown(explainerId: String) = {
-    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("publication-state--loading")
+    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("state-indicator--loading")
     Model.takeDown(explainerId) onComplete {
       case Success(_) =>
         State.takenDown = true

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -16,6 +16,7 @@ import scala.scalajs.js.{Function0, Object => JsObject}
 import services.State
 import shared.models._
 import shared.util.SharedHelperFunctions
+import scala.scalajs.js.timers._
 
 
 @JSExport
@@ -63,7 +64,10 @@ object ExplainEditor {
 
 
   def updateEmbedUrlAndStatusLabel(id: String, status: PublicationStatus) = {
-    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.remove("publication-state--loading")
+    // show spinner for 4s to allow fastly cache to purge
+    setTimeout(4000) {
+      dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.remove("publication-state--loading")
+    }
     StatusBar.updateStatusBar(status)
     Sidebar.republishembedURL(id, status)
   }

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -3,6 +3,7 @@ package views
 import api.Model
 import components.{ScribeBodyEditor, Sidebar, StatusBar, TagPickers}
 import org.scalajs.dom
+import org.scalajs.dom.html.Div
 import services.PresenceClient
 import shared.models.UpdateField.{Body, DisplayType, RemoveTag, UpdateField}
 import shared.models.{CsAtom, ExplainerUpdate}
@@ -62,12 +63,14 @@ object ExplainEditor {
 
 
   def updateEmbedUrlAndStatusLabel(id: String, status: PublicationStatus) = {
+    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.remove("publication-state--loading")
     StatusBar.updateStatusBar(status)
     Sidebar.republishembedURL(id, status)
   }
 
   @JSExport
   def publish(explainerId: String) = {
+    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("publication-state--loading")
     Model.publish(explainerId) onComplete {
       case Success(_) =>
         State.takenDown = false
@@ -78,6 +81,7 @@ object ExplainEditor {
 
   @JSExport
   def takeDown(explainerId: String) = {
+    dom.document.getElementById("publication-state-icon").asInstanceOf[Div].classList.add("publication-state--loading")
     Model.takeDown(explainerId) onComplete {
       case Success(_) =>
         State.takenDown = true

--- a/explainer-server/app/config/Config.scala
+++ b/explainer-server/app/config/Config.scala
@@ -51,6 +51,9 @@ class Config @Inject() (conf: Configuration) extends AwsInstanceTags {
 
   val ophanUrl = "<<unused>>"
 
+  val fastlyPurgingEnabled = stage =="PROD"
+  val fastlyAPIKey = fetchOrErrorOptionalProperty(fastlyPurgingEnabled, "fastly.apikey", "fastly api key required when fastly purging enabled")
+
   lazy val region = {
     val r = conf.getString("aws.region").map(Regions.fromName).getOrElse(Regions.EU_WEST_1)
     Region.getRegion(r)

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -115,15 +115,14 @@ class ExplainerApiImpl(
     }
   }
 
-  def sendFastlyPurgeRequest(id: String) = {
-    if (config.fastlyPurgingEnabled) {
+  def sendFastlyPurgeRequest(id: String): Future[Unit] = {
+    Future { if (config.fastlyPurgingEnabled) {
       val purgeRequest = ws.url(s"https://explainers-api.guim.co.uk/atom/explainer/$id").withMethod("PURGE").withHeaders(("Fastly-Key", config.fastlyAPIKey))
-      Future(Thread.sleep(4000)).onComplete{ _ =>
-        purgeRequest.execute().foreach{ r =>
-          Logger.debug(s"Fastly purge request result: ${r.status} ${r.statusText}, ${r.body}")
-        }
+      Thread.sleep(5000)
+      purgeRequest.execute().foreach { r =>
+        Logger.debug(s"Fastly purge request result: ${r.status} ${r.statusText}, ${r.body}")
       }
-    }
+    }}
   }
 
   private def sendKinesisEvent(explainer: Atom, actionMessage: String, atomPublisher: AtomPublisher, eventType: EventType = EventType.Update): PublishResult = {

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -120,7 +120,7 @@ class ExplainerApiImpl(
       val purgeRequest = ws.url(s"https://explainers-api.guim.co.uk/atom/explainer/$id").withMethod("PURGE").withHeaders(("Fastly-Key", config.fastlyAPIKey))
       Thread.sleep(5000)
       purgeRequest.execute().foreach { r =>
-        Logger.debug(s"Fastly purge request result: ${r.status} ${r.statusText}, ${r.body}")
+        Logger.info(s"Fastly purge request result: ${r.status} ${r.statusText}, ${r.body}")
       }
     }}
   }

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -118,7 +118,7 @@ class ExplainerApiImpl(
   def sendFastlyPurgeRequest(id: String) = {
     if (config.fastlyPurgingEnabled) {
       val purgeRequest = ws.url(s"https://explainers-api.guim.co.uk/atom/explainer/$id").withMethod("PURGE").withHeaders(("Fastly-Key", config.fastlyAPIKey))
-      Future(Thread.sleep(5000)).onComplete{ _ =>
+      Future(Thread.sleep(4000)).onComplete{ _ =>
         purgeRequest.execute().foreach{ r =>
           Logger.debug(s"Fastly purge request result: ${r.status} ${r.statusText}, ${r.body}")
         }

--- a/explainer-server/app/util/HelperFunctions.scala
+++ b/explainer-server/app/util/HelperFunctions.scala
@@ -77,9 +77,4 @@ object HelperFunctions {
     }
     AtomData.Explainer(updatedExplainerAtom)
   }
-
-  def sendFastlyPurgeRequest(explainerId: String)(ws: WSClient): Future[WSResponse] = {
-    val purgeRequest = ws.url(s"https://explainers-api.guim.co.uk/atom/explainer/$explainerId").withMethod("PURGE")
-    purgeRequest.execute()
-  }
 }

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -29,6 +29,13 @@
             </div>
         </div>
         <div class="top-toolbar__container">
+            <div class="top-toolbar__item top-toolbar__item--no-spacing">
+                <a class="top-toolbar__button"
+                target="_blank"
+                href="https://docs.google.com/document/d/1-o4kOXINgsxxotUYlkEoyqcwnJLrtc54Nv7m2S3l_7c/edit?ts=57e13f8a">
+                    How-to Guide
+                </a>
+            </div>
             <div class="top-toolbar__item">
                 <div class="top-toolbar__item-inner">
                     <div id="presence-names-display-wrapper"></div>

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -35,8 +35,9 @@
                 </div>
             </div>
             <div class="top-toolbar__item">
-                <div class="top-toolbar__item-inner">
-                    <div id = "explainer-publication-status" class="label-container"></div>
+                <div id="publication-state-icon" class="top-toolbar__item-inner publication-state">
+                    <i class="publication-state__icon i i-loading"></i>
+                    <div id = "explainer-publication-status" class="label-container publication-state__message"></div>
                 </div>
             </div>
             <div class="top-toolbar__item top-toolbar__item--no-spacing">

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -22,9 +22,9 @@
                 </div>
             </a>
             <div class="top-toolbar__item">
-                <div class="top-toolbar__item-inner save-state">
-                    <i class="save-state__icon i i-loading"></i>
-                    <span class="label label-container label--success save-state__message">Saved</span>
+                <div class="top-toolbar__item-inner save-state state-indicator">
+                    <i class="state-indicator__icon i i-loading"></i>
+                    <span class="label label-container label--success state-indicator__message">Saved</span>
                 </div>
             </div>
         </div>
@@ -35,9 +35,9 @@
                 </div>
             </div>
             <div class="top-toolbar__item">
-                <div id="publication-state-icon" class="top-toolbar__item-inner publication-state">
-                    <i class="publication-state__icon i i-loading"></i>
-                    <div id = "explainer-publication-status" class="label-container publication-state__message"></div>
+                <div id="publication-state-icon" class="top-toolbar__item-inner state-indicator">
+                    <i class="state-indicator__icon i i-loading"></i>
+                    <div id = "explainer-publication-status" class="label-container state-indicator__message"></div>
                 </div>
             </div>
             <div class="top-toolbar__item top-toolbar__item--no-spacing">

--- a/explainer-server/public/javascripts/explain-editor-plain-js.js
+++ b/explainer-server/public/javascripts/explain-editor-plain-js.js
@@ -154,7 +154,7 @@ function setupScribe() {
 
 
             scribe.on('content-changed', function() {
-                $(".save-state").addClass("save-state--loading");
+                $(".save-state").addClass("state-indicator--loading");
             });
 
             scribe.on('content-changed',  debounce(function() {
@@ -162,7 +162,7 @@ function setupScribe() {
                 updateWordCountDisplay();
                 updateWordCountWarningDisplay();
                 explainEditor.updateBodyContents(CONFIG.EXPLAINER_IDENTIFIER, bodyString);
-                $(".save-state").removeClass("save-state--loading");
+                $(".save-state").removeClass("state-indicator--loading");
             }, 500));
 
         });

--- a/explainer-server/public/stylesheets/scss/layout/_sidebar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_sidebar.scss
@@ -12,13 +12,8 @@
   overflow: auto;
 }
 
-.preview-link {
-  display: inline;
-  color: $c-blue-link;
-
-  &--hidden {
-    display: none;
-  }
+.simple-link {
+  color: $brand-color;
 }
 
 .text-atom-guide-link {

--- a/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
@@ -151,7 +151,7 @@ $toolbarHeight: 50px;
   height: 100%;
 }
 
-.publication-state, .save-state {
+.state-indicator {
   position: relative;
 
   &__icon {
@@ -163,13 +163,11 @@ $toolbarHeight: 50px;
   }
 
   &--loading {
-    .publication-state__icon,
-    .save-state__icon {
+    .state-indicator__icon {
       visibility: visible;
     }
 
-    .publication-state__message,
-    .save-state__message {
+    .state-indicator__message {
       visibility: hidden;
     }
   }

--- a/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
@@ -151,7 +151,7 @@ $toolbarHeight: 50px;
   height: 100%;
 }
 
-.save-state {
+.publication-state .save-state {
   position: relative;
 
   &__icon {
@@ -163,11 +163,35 @@ $toolbarHeight: 50px;
   }
 
   &--loading {
+    .publication-state__icon
     .save-state__icon {
       visibility: visible;
     }
 
+    .publication-state__message
     .save-state__message {
+      visibility: hidden;
+    }
+  }
+}
+
+.publication-state {
+  position: relative;
+
+  &__icon {
+    visibility: hidden;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+
+  &--loading {
+    .publication-state__icon {
+      visibility: visible;
+    }
+
+    .publication-state__message {
       visibility: hidden;
     }
   }

--- a/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
@@ -151,7 +151,7 @@ $toolbarHeight: 50px;
   height: 100%;
 }
 
-.publication-state .save-state {
+.publication-state, .save-state {
   position: relative;
 
   &__icon {
@@ -163,35 +163,13 @@ $toolbarHeight: 50px;
   }
 
   &--loading {
-    .publication-state__icon
+    .publication-state__icon,
     .save-state__icon {
       visibility: visible;
     }
 
-    .publication-state__message
+    .publication-state__message,
     .save-state__message {
-      visibility: hidden;
-    }
-  }
-}
-
-.publication-state {
-  position: relative;
-
-  &__icon {
-    visibility: hidden;
-    position: absolute;
-    left: 50%;
-    top: 50%;
-    transform: translate(-50%, -50%);
-  }
-
-  &--loading {
-    .publication-state__icon {
-      visibility: visible;
-    }
-
-    .publication-state__message {
       visibility: hidden;
     }
   }


### PR DESCRIPTION
The 5s delay should allow capi to update with the latest version of the content before we do the purge, therefore preventing the old version from being cached again.

The delay is non-blocking, but we show a spinner to the user to make the update time more obvious.
