### PR TITLE
Add page showing usages of an explainer in content.

### DIFF
--- a/explainer-server/app/controllers/ExplainEditorController.scala
+++ b/explainer-server/app/controllers/ExplainEditorController.scala
@@ -80,4 +80,10 @@ class ExplainEditorController @Inject() (
     }
 
   }
+
+  def findUsages(id: String, title:Option[String]) = pandaAuthenticated.async { implicit request =>
+    capiService.findExplainerUsages(s""""$id"""").map{ usages =>
+      Ok(views.html.usages(title.getOrElse(id), usages))
+    }
+  }
 }

--- a/explainer-server/app/services/CAPIService.scala
+++ b/explainer-server/app/services/CAPIService.scala
@@ -4,7 +4,7 @@ import javax.inject.Inject
 
 import com.gu.contentapi.client.{ContentApiClientLogic, GuardianContentClient}
 import com.gu.contentapi.client.model.{ItemQuery, SearchQuery, TagsQuery}
-import com.gu.contentapi.client.model.v1.{ItemResponse, Tag}
+import com.gu.contentapi.client.model.v1.{ItemResponse, SearchResponse, Tag}
 import com.gu.contentapi.client.Parameters
 import config.Config
 import play.api.cache._
@@ -38,6 +38,11 @@ class CAPIService @Inject() (config: Config, cache: CacheApi) {
       r.results
     })
 
+  }
+
+  def findExplainerUsages(explainerId: String): Future[Seq[String]] = {
+    val searchQuery = SearchQuery().q(explainerId)
+    client.getResponse(searchQuery).map(_.results.map(_.webUrl))
   }
 
   def getTrackingTags: Future[Seq[Tag]] = {

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -109,7 +109,7 @@
                                 </a>
                             </div>
                         </td>
-                        <td class="explainer-list__item"><a class="explainer-list__link" target="_blank" href="/explain/@e.id/usages?title=@ExplainerAtomImplicits.AtomWithData(e).tdata.title">Find usages</a></td>
+                        <td class="explainer-list__item"><a class="explainer-list__link" href="/explain/@e.id/usages?title=@ExplainerAtomImplicits.AtomWithData(e).tdata.title">Find usages</a></td>
                     </tr>
                 }
             </table>

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -82,11 +82,12 @@
                     <th class="explainer-list__header">Publication status</th>
                     <th class="explainer-list__header">Workflow status</th>
                     <th class="explainer-list__header">Ophan</th>
+                    <th class="explainer-list__header"></th>
                 </tr>
                 @for(e <- explainers) {
                     <tr class="explainer-list__row">
                         <td class="explainer-list__item">
-                            <a class="explainer-list__link" href="/explain/@e.id">@{if(ExplainerAtomImplicits.AtomWithData(e).tdata.title.trim.length>0){
+                            <a class="explainer-list__link explainer-list__editor-link" href="/explain/@e.id">@{if(ExplainerAtomImplicits.AtomWithData(e).tdata.title.trim.length>0){
                                 ExplainerAtomImplicits.AtomWithData(e).tdata.title
                             } else {
                                 "untitled"
@@ -108,6 +109,7 @@
                                 </a>
                             </div>
                         </td>
+                        <td class="explainer-list__item"><a class="explainer-list__link" target="_blank" href="/explain/@e.id/usages?title=@ExplainerAtomImplicits.AtomWithData(e).tdata.title">Find usages</a></td>
                     </tr>
                 }
             </table>

--- a/explainer-server/app/views/usages.scala.html
+++ b/explainer-server/app/views/usages.scala.html
@@ -22,8 +22,8 @@
         <div class="page-title">
             <h1>Usages of @{explainerTitle}</h1>
         </div>
-        <p>This is an experimental feature. It should work the vast majority of the time, but if you need to be absolutely
-            confident that you have found all occurences of a text atom, please contact digitalcms.dev@@guardian.co.uk.</p>
+        <p>This is an experimental feature. If you need to be absolutely confident that you have found all occurrences
+            of a text atom, please contact digitalcms.dev@@guardian.co.uk.</p>
         <b>@{if(usages.isEmpty){"No usages found"}}</b>
         <ul>
         @for(u <- usages) {

--- a/explainer-server/app/views/usages.scala.html
+++ b/explainer-server/app/views/usages.scala.html
@@ -7,6 +7,10 @@
             <a class="top-toolbar__title" href="/">
                 <div class="top-toolbar__logo"></div>
                 <div class="top-toolbar__page-icon"></div>
+                <div class="top-toolbar__title__hover-state">
+                    <span class="top-toolbar__title__hover-state__subtitle">Back to</span><br />
+                    <span class="top-toolbar__title__hover-state__title">Dashboard</span>
+                </div>
             </a>
         </div>
     </header>

--- a/explainer-server/app/views/usages.scala.html
+++ b/explainer-server/app/views/usages.scala.html
@@ -24,6 +24,7 @@
         </div>
         <p>This is an experimental feature. It should work the vast majority of the time, but if you need to be absolutely
             confident that you have found all occurences of a text atom, please contact digitalcms.dev@@guardian.co.uk.</p>
+        <b>@{if(usages.isEmpty){"No usages found"}}</b>
         <ul>
         @for(u <- usages) {
             <li><a class="explainer-list__link" href="@u">@u</a></li>

--- a/explainer-server/app/views/usages.scala.html
+++ b/explainer-server/app/views/usages.scala.html
@@ -1,0 +1,28 @@
+
+@(explainerTitle: String, usages: Seq[String])(implicit request: RequestHeader)
+
+@toolbar = {
+    <header class="top-toolbar">
+        <div class="top-toolbar__container">
+            <a class="top-toolbar__title" href="/">
+                <div class="top-toolbar__logo"></div>
+                <div class="top-toolbar__page-icon"></div>
+            </a>
+        </div>
+    </header>
+}
+
+@main("Explainers", toolbar){
+    <div class="container block-center">
+
+        <div class="page-title">
+            <h1>Usages of @{explainerTitle}</h1>
+
+        </div>
+        <ul>
+        @for(u <- usages) {
+            <li><a class="explainer-list__link" href="@u">@u</a></li>
+        }
+        </ul>
+    </div>
+}

--- a/explainer-server/app/views/usages.scala.html
+++ b/explainer-server/app/views/usages.scala.html
@@ -17,8 +17,9 @@
 
         <div class="page-title">
             <h1>Usages of @{explainerTitle}</h1>
-
         </div>
+        <p>This is an experimental feature. It should work the vast majority of the time, but if you need to be absolutely
+            confident that you have found all occurences of a text atom, please contact digitalcms.dev@@guardian.co.uk.</p>
         <ul>
         @for(u <- usages) {
             <li><a class="explainer-list__link" href="@u">@u</a></li>

--- a/explainer-server/conf/routes
+++ b/explainer-server/conf/routes
@@ -8,6 +8,7 @@ GET           /                            controllers.ExplainEditorController.l
 
 # Explain Editor
 GET           /explain/:id                 controllers.ExplainEditorController.get(id)
+GET           /explain/:id/usages          controllers.ExplainEditorController.findUsages(id, title: Option[String])
 
 # Autowire calls
 POST          /api/*path                   controllers.ApiController.autowireApi(path: String)

--- a/explainer-server/public/stylesheets/scss/layout/_explainer.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_explainer.scss
@@ -70,11 +70,14 @@
         cursor: pointer;
         padding: 5px 0;
         display: block;
-        width: 300px;
 
         &:hover {
             text-decoration: underline;
         }
+    }
+
+    &__editor-link {
+        width: 300px;
     }
 }
 


### PR DESCRIPTION
This will make it easier to find pieces of content with explainers in them. It's not ideal as it just relies on an exact string search in the content api. I've added a warning that it might not find every occurence

![screen shot 2016-10-04 at 12 41 53](https://cloud.githubusercontent.com/assets/3606555/19073014/861db4aa-8a30-11e6-973f-4858ed5372ce.png)
![screen shot 2016-10-04 at 12 45 27](https://cloud.githubusercontent.com/assets/3606555/19073019/89a38f3c-8a30-11e6-80a3-31723b0a3607.png)
