### PR TITLE
Show the section name in the tags picker

### DIFF
--- a/explainer-client/src/main/scala/components/TagPickers.scala
+++ b/explainer-client/src/main/scala/components/TagPickers.scala
@@ -69,10 +69,11 @@ object TagPickers {
     )
   }
 
-  def renderSuggestionSet(tags:List[CsTag], explainerId:String, suggestionsDivIdentifier:String) = {
-    g.jQuery(s"#$suggestionsDivIdentifier").empty()
+  def renderSuggestionSet(tags:List[CsTag], explainerId:String, suggestionsDivIdentifier:String, includeSectionName: Boolean = false) = {
+    dom.document.getElementById(suggestionsDivIdentifier).innerHTML = ""
     tags.foreach( tagObject => {
-      val node = button(cls:="tag__result")(tagObject.webTitle).render
+      val sectionNameString = if(includeSectionName) s"(${tagObject.sectionName})" else ""
+      val node = button(cls:="tag__result")(s"${tagObject.webTitle} $sectionNameString").render
       node.onmousedown = (x: Event) => {
         Model.updateFieldContent(explainerId, ExplainerUpdate(AddTag, tagObject.id)).map { explainer =>
           redisplayExplainerTagManagementAreas(explainer)
@@ -96,7 +97,7 @@ object TagPickers {
       val queryValue: String = dom.document.getElementById("explainer-editor__tags__tag-search-input-field").asInstanceOf[Input].value
 
       CAPIClient.capiTagRequest(Seq("type" -> "keyword", "q" -> queryValue))
-        .map(renderSuggestionSet(_, explainer.id, suggestionsDivIdentifier))
+        .map(renderSuggestionSet(_, explainer.id, suggestionsDivIdentifier, includeSectionName = true))
     }
 
     def clearSuggestions() = {

--- a/explainer-server/app/controllers/ExplainerApiImpl.scala
+++ b/explainer-server/app/controllers/ExplainerApiImpl.scala
@@ -9,6 +9,7 @@ import org.joda.time.DateTime
 import play.api.cache.CacheApi
 import play.api.Logger
 import com.gu.atom.publish.{AtomPublisher, LiveAtomPublisher, PreviewAtomPublisher}
+import com.gu.contentapi.client.model.v1.TagType
 import com.gu.contentatom.thrift._
 import com.gu.contentatom.thrift.atom.explainer.{ExplainerAtom, DisplayType => ThriftDisplayType}
 import config.Config
@@ -119,7 +120,7 @@ class ExplainerApiImpl(
 
   override def getTrackingTags(): Future[Seq[CsTag]] = {
     capiService.getTrackingTags.map{ tags =>
-      tags.map(t => CsTag(t.id, t.webTitle))
+      tags.map(t => CsTag(t.id, t.webTitle, t.sectionName.getOrElse("unknown section"), t.`type`.name))
     }
   }
 

--- a/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
+++ b/explainer-shared/src/main/scala/shared/models/ClientSideModels.scala
@@ -43,4 +43,4 @@ object CsAtom extends ExplainerAtomImplicits {
 
 }
 
-case class CsTag(id:String, webTitle: String)
+case class CsTag(id:String, webTitle: String, sectionName: String = "unknown section",`type`: String)


### PR DESCRIPTION
This will allow editors to differentiate between e.g. syria weather and syria country.
