### PR TITLE
Delete explainer feature

### DIFF
--- a/explainer-client/src/main/scala/api/Ajaxer.scala
+++ b/explainer-client/src/main/scala/api/Ajaxer.scala
@@ -48,6 +48,10 @@ object Model {
     Ajaxer[ExplainerApi].takeDown(id).call()
   }
 
+  def delete(id: String): Future[Unit] = {
+    Ajaxer[ExplainerApi].delete(id).call()
+  }
+
   def getExplainerStatus(explainerId: String): Future[PublicationStatus] = {
     Ajaxer[ExplainerApi].getStatus(explainerId).call()
   }

--- a/explainer-client/src/main/scala/views/ExplainList.scala
+++ b/explainer-client/src/main/scala/views/ExplainList.scala
@@ -4,14 +4,17 @@ import api.Model
 import components.ExplainListComponents
 import org.scalajs.dom
 import org.scalajs.dom.Event
-import org.scalajs.dom.html.Select
-import shared.models.CsAtom
+import org.scalajs.dom.html._
+import services.State
+import shared.models.{TakenDown, CsAtom}
 
 import scala.scalajs.concurrent.JSExecutionContext.Implicits.queue
 import scala.scalajs.js.Dynamic.{global => g}
 import scala.scalajs.js.URIUtils
 import scala.scalajs.js.annotation.JSExport
 import org.scalajs.dom._
+
+import scala.util.{Failure, Success}
 
 @JSExport
 object ExplainList {
@@ -125,6 +128,26 @@ object ExplainList {
     Model.getTrackingTags.map{ tags =>
       val opts = ExplainListComponents.tagsToSelectOptions(tags, deskDropdown.value)
       deskDropdown.appendChild(opts)
+    }
+  }
+
+  @JSExport
+  def delete(explainerId: String) = {
+    dom.document.getElementById(s"delete-button__$explainerId").classList.add("delete-button-hidden")
+    dom.document.getElementById(s"delete-confirmation-button__$explainerId").classList.remove("delete-button-hidden")
+  }
+
+  @JSExport
+  def resetDelete(explainerId: String) = {
+    dom.document.getElementById(s"delete-button__$explainerId").classList.remove("delete-button-hidden")
+    dom.document.getElementById(s"delete-confirmation-button__$explainerId").classList.add("delete-button-hidden")
+  }
+
+  @JSExport
+  def deleteConfirmation(explainerId: String) = {
+    Model.delete(explainerId) onComplete {
+      case Success(_) => dom.document.location.reload()
+      case Failure(_) => g.console.error(s"Failed to delete explainer")
     }
   }
 }

--- a/explainer-server/app/db/ExplainerDB.scala
+++ b/explainer-server/app/db/ExplainerDB.scala
@@ -86,6 +86,10 @@ class ExplainerDB @Inject() (
     Scanamo.delete(config.dynamoClient)(config.liveTableName)('id -> explainer.id)
   }
 
+  def delete(explainerId: String) = {
+    Scanamo.delete(config.dynamoClient)(config.previewTableName)('id -> explainerId)
+  }
+
   implicit val workflowStatusFormat = DynamoFormat.coercedXmap[WorkflowStatus, String, IllegalArgumentException](
     WorkflowStatus(_))(_.toString)
 

--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -12,6 +12,7 @@
 @import shared.models.{Available, Draft, UnlaunchedChanges}
 @import config.Config
 
+@import shared.models.TakenDown
 @(explainers: Seq[Atom], user: User, desk: Option[String],
         paginationConfig: PaginationConfig, statusMap: Map[String, WorkflowStatus],
         publicationStatusMap: Map[String, PublicationStatus], config: Config)(implicit request: RequestHeader)
@@ -83,6 +84,7 @@
                     <th class="explainer-list__header">Workflow status</th>
                     <th class="explainer-list__header">Ophan</th>
                     <th class="explainer-list__header"></th>
+                    <th class="explainer-list__header"></th>
                 </tr>
                 @for(e <- explainers) {
                     <tr class="explainer-list__row">
@@ -110,6 +112,16 @@
                             </div>
                         </td>
                         <td class="explainer-list__item"><a class="explainer-list__link" href="/explain/@e.id/usages?title=@ExplainerAtomImplicits.AtomWithData(e).tdata.title">Find this atom</a></td>
+                        <td class="explainer-list__item">
+                            <div class="@{if(publicationStatusMap.get(e.id).exists(s => s != TakenDown && s != Draft)){"delete-button-hidden"}} explainer-list__delete">
+                                <div id="delete-button__@e.id">
+                                    <button type="button" onclick="views.ExplainList().delete('@e.id')"><i class="block-center i-delete"></i></button>
+                                </div>
+                                <div id="delete-confirmation-button__@e.id" class="delete-button-hidden">
+                                    <button type="button" class="btn btn--cancel" onclick="views.ExplainList().deleteConfirmation('@e.id')" onmouseout="views.ExplainList().resetDelete('@e.id')">Confirm delete</button>
+                                </div>
+                            </div>
+                        </td>
                     </tr>
                 }
             </table>

--- a/explainer-server/public/stylesheets/scss/components/_buttons.scss
+++ b/explainer-server/public/stylesheets/scss/components/_buttons.scss
@@ -26,8 +26,5 @@ button {
   &.btn--cancel {
     background-color: $c-red;
     line-height: 6px;
-    &:hover {
-      background-color: $c-green;
-    }
   }
 }

--- a/explainer-server/public/stylesheets/scss/components/_buttons.scss
+++ b/explainer-server/public/stylesheets/scss/components/_buttons.scss
@@ -25,6 +25,7 @@ button {
 
   &.btn--cancel {
     background-color: $c-red;
+    line-height: 6px;
     &:hover {
       background-color: $c-green;
     }

--- a/explainer-server/public/stylesheets/scss/components/_buttons.scss
+++ b/explainer-server/public/stylesheets/scss/components/_buttons.scss
@@ -22,4 +22,11 @@ button {
   &:hover {
     background: $brand-color-light;
   }
+
+  &.btn--cancel {
+    background-color: $c-red;
+    &:hover {
+      background-color: $c-green;
+    }
+  }
 }

--- a/explainer-server/public/stylesheets/scss/components/_icons.scss
+++ b/explainer-server/public/stylesheets/scss/components/_icons.scss
@@ -16,3 +16,11 @@
   display: block;
   fill: $c-grey-600;
 }
+
+.i-delete {
+  background: url('../images/icons/delete.svg');
+  width: 20px;
+  height: 20px;
+  display: block;
+  fill: $c-grey-600;
+}

--- a/explainer-server/public/stylesheets/scss/layout/_explainer.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_explainer.scss
@@ -79,10 +79,19 @@
     &__editor-link {
         width: 300px;
     }
+
+    &__delete {
+        width: 100px;
+        text-align: right;
+    }
 }
 
 .ophan-link-hidden {
     visibility:hidden;
+}
+
+.delete-button-hidden {
+    display: none;
 }
 /* -------------------------------------- */
 /* Presence                               */

--- a/explainer-server/public/stylesheets/scss/layout/_explainer.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_explainer.scss
@@ -77,12 +77,16 @@
     }
 
     &__editor-link {
-        width: 300px;
+        width: 250px;
     }
 
     &__delete {
         width: 100px;
         text-align: right;
+
+        & button {
+            vertical-align: middle;
+        }
     }
 }
 

--- a/explainer-shared/src/main/scala/shared/ExplainerApi.scala
+++ b/explainer-shared/src/main/scala/shared/ExplainerApi.scala
@@ -12,6 +12,7 @@ trait ExplainerApi {
   def update(id: String, explainerUpdate: ExplainerUpdate): Future[CsAtom]
   def publish(id: String): Future[CsAtom]
   def takeDown(id: String): Future[CsAtom]
+  def delete(id: String): Future[Unit]
   def getStatus(id: String): Future[PublicationStatus]
 
   def getWorkflowData(id:String): WorkflowData


### PR DESCRIPTION
This will delete an atom explainer only if the atom is taken down or draft. It works in 2 steps: first you click on the icon and you get a button and then you confirm the delete. The page will reload after the action is completed.

![n67xtyxzm2](https://cloud.githubusercontent.com/assets/5732563/19937884/d6ed20cc-a11a-11e6-8462-c31fe95e14a0.gif)

@philmcmahon 