### PR TITLE
Add warning message when more than one person editing explainer

### DIFF
--- a/explainer-client/src/main/scala/services/PresenceClient.scala
+++ b/explainer-client/src/main/scala/services/PresenceClient.scala
@@ -10,7 +10,7 @@ import scala.scalajs.js
 import scala.scalajs.js.Dynamic.{global => g}
 
 object PresenceClient {
-  val endpoint = g.CONFIG.PRESENCE_ENDPOINT_URL.toString
+  val endpoint = s"wss://presence.${g.CONFIG.PRESENCE_ENDPOINT_URL.toString}/socket"
   val person = new Person(g.CONFIG.USER_FIRSTNAME.toString, g.CONFIG.USER_LASTNAME.toString, g.CONFIG.USER_EMAIL_ADDRESS.toString)
   val presenceClient = PresenceGlobalScope.presenceClient(endpoint, person)
   def attachPresenceEventHandlerToElement(explainerId: String, element: Element) = {
@@ -27,6 +27,11 @@ object PresenceClient {
   def activatePresenceHandler() = {
     presenceClient.on("visitor-list-updated", { data: js.Object =>
       val stateChange = upickle.default.read[StateChange](js.JSON.stringify(data))
+      if (stateChange.currentState.length > 1) {
+        dom.document.getElementById("presence-warning-message").classList.remove("visually-hidden")
+      } else {
+        dom.document.getElementById("presence-warning-message").classList.add("visually-hidden")
+      }
       val statesOnThisArea: Seq[StateChange.State] = stateChange.currentState.filter(_.location == "document")
       dom.document.getElementById("presence-names-display-wrapper").innerHTML = statesOnThisArea.map(_.clientId.person.initials).map( i => span(cls:="presence-names-single")(i) ).mkString(" ")
       ()

--- a/explainer-client/src/main/scala/services/PresenceClient.scala
+++ b/explainer-client/src/main/scala/services/PresenceClient.scala
@@ -4,6 +4,7 @@ import jslibwrappers.{Person, PresenceGlobalScope}
 import org.scalajs.dom
 import org.scalajs.dom._
 import org.scalajs.dom.html.Element
+import scalatags.JsDom.all._
 
 import scala.scalajs.js
 import scala.scalajs.js.Dynamic.{global => g}
@@ -14,7 +15,7 @@ object PresenceClient {
   val presenceClient = PresenceGlobalScope.presenceClient(endpoint, person)
   def attachPresenceEventHandlerToElement(explainerId: String, element: Element) = {
     element.onmouseover = (x: MouseEvent) => {
-      presenceClient.enter("explain-" + explainerId, "document")
+      presenceClient.enter(s"explain-$explainerId", "document")
     }
     enterDocument(explainerId)
     activatePresenceHandler()
@@ -27,7 +28,7 @@ object PresenceClient {
     presenceClient.on("visitor-list-updated", { data: js.Object =>
       val stateChange = upickle.default.read[StateChange](js.JSON.stringify(data))
       val statesOnThisArea: Seq[StateChange.State] = stateChange.currentState.filter(_.location == "document")
-      dom.document.getElementById("presence-names-display-wrapper").innerHTML = statesOnThisArea.map(_.clientId.person.initials).map( i => s"<span class=${ "presence-names-single" }>${i}</span>" ).mkString(" ")
+      dom.document.getElementById("presence-names-display-wrapper").innerHTML = statesOnThisArea.map(_.clientId.person.initials).map( i => span(cls:="presence-names-single")(i) ).mkString(" ")
       ()
     })
   }

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -2,10 +2,9 @@ package views
 
 import api.Model
 import components.{ScribeBodyEditor, Sidebar, StatusBar, TagPickers}
-import fr.hmil.roshttp.HttpRequest
 import org.scalajs.dom
 import org.scalajs.dom.html.Div
-import services.{PresenceClient, State, StateChange}
+import services.{PresenceClient, State}
 import shared.models.UpdateField.{Body, DisplayType, RemoveTag, UpdateField}
 import shared.models.ExplainerUpdate
 
@@ -16,8 +15,6 @@ import scala.util.{Failure, Success}
 import scala.scalajs.js.{Function0, Object => JsObject}
 import shared.models._
 import shared.util.SharedHelperFunctions
-import scala.concurrent.Future
-import scala.scalajs.js.JSON
 import scala.scalajs.js.timers._
 
 
@@ -56,20 +53,6 @@ object ExplainEditor {
       callback()
     }
 
-    checkNumberOfUserInExplainer(explainerId).foreach{no =>
-      if (no >= 2) println("DANGER")
-    }
-
-  }
-
-  def checkNumberOfUserInExplainer(id: String): Future[Int] = {
-    val presenceApiRequest = HttpRequest(s"${g.CONFIG.PRESENCE_ENDPOINT_URL.toString}/api/currentState/explain-$id")
-
-    presenceApiRequest.send().map{r =>
-      val sc = upickle.default.read[StateChange](JSON.stringify(r.body))
-      sc.currentState.length
-    }
-
   }
 
   def updateFieldAndRefresh(explainerId: String, updateField: UpdateField, updateValue: String, errorMessage: String) = {
@@ -78,7 +61,6 @@ object ExplainEditor {
       case Failure(_) => g.console.error(errorMessage)
     }
   }
-
 
   def updateEmbedUrlAndStatusLabel(id: String, status: PublicationStatus) = {
     StatusBar.updateStatusBar(status)

--- a/explainer-client/src/main/scala/views/ExplainEditor.scala
+++ b/explainer-client/src/main/scala/views/ExplainEditor.scala
@@ -2,9 +2,10 @@ package views
 
 import api.Model
 import components.{ScribeBodyEditor, Sidebar, StatusBar, TagPickers}
+import fr.hmil.roshttp.HttpRequest
 import org.scalajs.dom
 import org.scalajs.dom.html.Div
-import services.PresenceClient
+import services.{PresenceClient, State, StateChange}
 import shared.models.UpdateField.{Body, DisplayType, RemoveTag, UpdateField}
 import shared.models.ExplainerUpdate
 
@@ -13,9 +14,10 @@ import scala.scalajs.js.Dynamic.{global => g}
 import scala.scalajs.js.annotation.JSExport
 import scala.util.{Failure, Success}
 import scala.scalajs.js.{Function0, Object => JsObject}
-import services.State
 import shared.models._
 import shared.util.SharedHelperFunctions
+import scala.concurrent.Future
+import scala.scalajs.js.JSON
 import scala.scalajs.js.timers._
 
 
@@ -53,6 +55,21 @@ object ExplainEditor {
       }
       callback()
     }
+
+    checkNumberOfUserInExplainer(explainerId).foreach{no =>
+      if (no >= 2) println("DANGER")
+    }
+
+  }
+
+  def checkNumberOfUserInExplainer(id: String): Future[Int] = {
+    val presenceApiRequest = HttpRequest(s"${g.CONFIG.PRESENCE_ENDPOINT_URL.toString}/api/currentState/explain-$id")
+
+    presenceApiRequest.send().map{r =>
+      val sc = upickle.default.read[StateChange](JSON.stringify(r.body))
+      sc.currentState.length
+    }
+
   }
 
   def updateFieldAndRefresh(explainerId: String, updateField: UpdateField, updateValue: String, errorMessage: String) = {

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -29,7 +29,7 @@
             </div>
             <div class="top-toolbar__item">
                 <div class="top-toolbar__item-inner">
-                    <span id="presence-warning-message" class="presence-warning visually-hidden">WARNING Someone else is editing this atom. By continuing you may overwrite their changes!</span>
+                    <span id="presence-warning-message" class="presence-warning visually-hidden">WARNING: Someone else is editing this atom. By continuing you may overwrite their changes!</span>
                 </div>
             </div>
         </div>

--- a/explainer-server/app/views/explainEditor.scala.html
+++ b/explainer-server/app/views/explainEditor.scala.html
@@ -27,6 +27,11 @@
                     <span class="label label-container label--success state-indicator__message">Saved</span>
                 </div>
             </div>
+            <div class="top-toolbar__item">
+                <div class="top-toolbar__item-inner">
+                    <span id="presence-warning-message" class="presence-warning visually-hidden">WARNING Someone else is editing this atom. By continuing you may overwrite their changes!</span>
+                </div>
+            </div>
         </div>
         <div class="top-toolbar__container">
             <div class="top-toolbar__item top-toolbar__item--no-spacing">

--- a/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
@@ -191,5 +191,4 @@ $toolbarHeight: 50px;
 .presence-warning {
   color: $c-red;
   text-transform: none;
-  display: none;
 }

--- a/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
+++ b/explainer-server/public/stylesheets/scss/layout/_toolbar.scss
@@ -187,3 +187,9 @@ $toolbarHeight: 50px;
     margin-right: 5px;
   }
 }
+
+.presence-warning {
+  color: $c-red;
+  text-transform: none;
+  display: none;
+}


### PR DESCRIPTION
Explain maker doesn't do atomic updates - any change to any field results in an overwrite of the entire atom. This is something that could be improved in future if we deem it necessary but for now we should at least warn people about the danger!

<img width="888" alt="screen shot 2016-12-12 at 10 47 07" src="https://cloud.githubusercontent.com/assets/3606555/21096969/3223d48c-c05a-11e6-9134-72e867ed0ca2.png">
