### PR TITLE
Remove the ability to create new explainer

### DIFF
--- a/explainer-server/app/views/explainList.scala.html
+++ b/explainer-server/app/views/explainList.scala.html
@@ -46,12 +46,6 @@
                             </select>
                         </label>
                     </li>
-                    <li class="nav__item top-toolbar__item top-toolbar__item--no-spacing">
-                        <button class="top-toolbar__button"
-                           type="button" onclick="views.ExplainList().createNewExplainer()">
-                            Create New
-                        </button>
-                    </li>
                 </ul>
             </nav>
             <div class="top-toolbar__user top-toolbar__item">


### PR DESCRIPTION
Remove the ability in the UI to create new explainer.
This the first step of the deprecation of the tool 