### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This repo is no longer in use and has been deleted in AWS.** 
+_Since legacy explainers can now be edited inside Atom Workshop, there is no need for a separate tool._ 
+
 # Explainer Atom Editor
 
 ### Architecture


### PR DESCRIPTION
Update Readme to explain deprecation of this tool. 

Atom Workshop can now handle explainer atoms, reducing the need for a separate tool. 