### PR TITLE
Update riff-raff.yaml

### DIFF
--- a/explainer-server/conf/riff-raff.yaml
+++ b/explainer-server/conf/riff-raff.yaml
@@ -6,7 +6,7 @@ deployments:
     app: explain-maker
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-xenial-java8-deprecated
         AmigoStage: PROD
         BuiltBy: amigo
   explain-maker:


### PR DESCRIPTION
In the move to `ssm`, we're removing the ssh-keys role from the AMIs that we use. The AMIgo recipe `editorial-tools-xenial-java8` no longer includes this role.

Explicitly use a deprecated AMIgo image, to make it obvious that this project needs updating.